### PR TITLE
Add missing time zone database on xenial/bionic

### DIFF
--- a/base/bionic/Dockerfile
+++ b/base/bionic/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update -qq && \
     libpcre3-dev \
     locales \
     sudo \
+    tzdata \
     wget \
     zlib1g-dev
 

--- a/base/xenial/Dockerfile
+++ b/base/xenial/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update -qq && \
     libpcre3-dev \
     locales \
     sudo \
+    tzdata \
     wget \
     zlib1g-dev
 

--- a/test/test.R
+++ b/test/test.R
@@ -8,3 +8,9 @@ library(R6)
 # Install a package with compilation
 install.packages("BASIX")
 library(BASIX)
+
+# Check that the time zone database is present
+# https://stat.ethz.ch/R-manual/R-devel/library/base/html/timezones.html
+if (length(OlsonNames()) == 0) {
+  stop("Time zone database not found")
+}

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -ex
 
 R --version
 


### PR DESCRIPTION
Time zone conversions weren't working since the Ubuntu xenial/bionic images don't come with time zone data, which R looks for at `/usr/share/zoneinfo`.
```r
> format(Sys.time(), usetz = TRUE)
[1] "2019-03-18 15:44:06 UTC"

> format(Sys.time(), usetz = TRUE, tz = "America/Chicago")
[1] "2019-03-18 15:44:13 America"

> OlsonNames()  # time zone names
character(0)
Warning message:
In OlsonNames() : no Olson database found
```

The Ubuntu images used to include the `tzdata` package but not anymore (https://github.com/docker-library/official-images/issues/2863), so adding it here. Time zone conversions should work now:
```r
> format(Sys.time(), usetz = TRUE)
[1] "2019-03-18 15:46:31 UTC"

> format(Sys.time(), usetz = TRUE, tz = "America/Chicago")
[1] "2019-03-18 10:46:37 CDT"

> head(OlsonNames())
[1] "Africa/Abidjan"     "Africa/Accra"       "Africa/Addis_Ababa"
[4] "Africa/Algiers"     "Africa/Asmara"      "Africa/Asmera"
```

