### PR TITLE
Add bzip2 on openSUSE 15

### DIFF
--- a/base/opensuse15/Dockerfile
+++ b/base/opensuse15/Dockerfile
@@ -11,6 +11,7 @@ RUN zypper --non-interactive --gpg-auto-import-keys -n install \
     glibc-locale \
     gzip \
     lapack-devel \
+    libbz2-devel \
     libcairo2 \
     libcurl-devel \
     libfreetype6 \


### PR DESCRIPTION
I missed adding bzip2 from https://github.com/rstudio/r-docker/pull/11. I think it's possible to test for the edge-case R devel dependencies by attempting to install a dummy package with C code in it, but I haven't looked into how to do that. The alternative would be to put some fairly expensive package installs in the test script (rJava, Matrix).