### PR TITLE
Enable newer C++ on CentOS 6 for Docker builds and non-interactive shells

### DIFF
--- a/base/centos6/Dockerfile
+++ b/base/centos6/Dockerfile
@@ -45,8 +45,14 @@ RUN yum install -y centos-release-scl && \
     devtoolset-8-gcc-gfortran && \
     yum clean all
 
-# Permanently enable newer C/C++ \
-COPY scl_enable.sh /etc/profile.d/scl_enable.sh
+# Permanently enable newer C/C++ for interactive and non-interactive use.
+# Note that this works for RUN instructions using the shell form only.
+# RUN instructions using the executable form can enable the newer C/C++ like:
+# RUN ["/usr/bin/scl_enable.sh", "gcc", "--version"]
+COPY scl_enable.sh /usr/bin/scl_enable.sh
+SHELL ["/usr/bin/scl_enable.sh", "/bin/sh", "-c"]
+ENTRYPOINT ["/usr/bin/scl_enable.sh"]
+CMD ["/bin/bash"]
 
 # Install pandoc
 RUN mkdir -p /opt/pandoc && \

--- a/base/centos6/scl_enable.sh
+++ b/base/centos6/scl_enable.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 # Permanently enable newer C/C++
 source scl_source enable devtoolset-8
+"$@"


### PR DESCRIPTION
Currently, the newer C/C++ compiler isn't being enabled for Docker builds or non-interactive use. For example:
```dockerfile
FROM rstudio/r-base:3.5-centos6

# This fails because the newer gcc we've added isn't enabled at Docker build time
RUN R -e 'install.packages("tidyverse", repos = "http://cloud.r-project.org")'
```
```sh
$ docker run --rm rstudio/r-base:3.6-centos6 gcc --version
gcc (GCC) 4.4.7 20120313 (Red Hat 4.4.7-23)
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

---

This adapts the entrypoint method from https://austindewey.com/2019/03/26/enabling-software-collections-binaries-on-a-docker-image/ to enable the SCL for both Dockerfile RUN commands and non-interactive shells as well. It's still not 100% foolproof though - `RUN` instructions that use the executable form still need to manually add the entrypoint.

Non-interactive example:
```
$ docker run --rm rstudio/r-base:centos6 /bin/bash -c 'gcc --version'
gcc (GCC) 8.2.1 20180905 (Red Hat 8.2.1-3)
Copyright (C) 2018 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

Interactive:
```sh
$ docker run -it --rm rstudio/r-base:centos6
[root@d098221676d0 /]# gcc --version
gcc (GCC) 8.2.1 20180905 (Red Hat 8.2.1-3)
Copyright (C) 2018 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

$ docker run -it --rm rstudio/r-base:3.5-centos6 /bin/bash
[root@e6c88e70348e /]# gcc --version
gcc (GCC) 8.2.1 20180905 (Red Hat 8.2.1-3)
Copyright (C) 2018 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

Docker build:
```dockerfile
FROM rstudio/r-base:centos6

RUN gcc --version
```
```sh
 $ docker build .
Sending build context to Docker daemon  1.386MB
Step 1/2 : FROM rstudio/r-base:centos6
 ---> 1f7a6379f996
Step 2/2 : RUN gcc --version
 ---> Running in f893504d07e8
gcc (GCC) 8.2.1 20180905 (Red Hat 8.2.1-3)
Copyright (C) 2018 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

Removing intermediate container f893504d07e8
 ---> 90ba538f549b
Successfully built 90ba538f549b
```

The one exception I've found where this doesn't work:
```dockerfile
FROM rstudio/r-base:centos6

RUN ["gcc", "--version"]  # only works with ["/usr/bin/scl_enable.sh", "gcc", "--version"]
```
```sh
$ docker build .
Sending build context to Docker daemon  1.386MB
Step 1/2 : FROM rstudio/r-base:centos6
 ---> 1f7a6379f996
Step 2/2 : RUN ["gcc", "--version"]
 ---> Running in 96e2d8d6451e
gcc (GCC) 4.4.7 20120313 (Red Hat 4.4.7-23)
Copyright (C) 2010 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

Removing intermediate container 96e2d8d6451e
 ---> 32c0c2edbeaa
Successfully built 32c0c2edbeaa
```