### PR TITLE
Add tests for download methods

### DIFF
--- a/test/test.R
+++ b/test/test.R
@@ -69,7 +69,10 @@ if (length(output) > 0) {
   stop(sprintf("unexpected output returned from plotting:\n%s", paste(output, collapse = "\n")))
 }
 
-# Check libcurl support (R >= 3.2)
+# Check download methods: libcurl (supported in R >= 3.2) and internal (based on libxml)
 if ("libcurl" %in% names(capabilities())) {
   download.file("https://cloud.r-project.org", tempfile(), "libcurl")
 }
+tmpfile <- tempfile()
+write.csv("test", tmpfile)
+download.file(sprintf("file://%s", tmpfile), tempfile(), "internal")


### PR DESCRIPTION
Adds some tests for the libcurl and internal (libxml2 based) download methods.

For future reference, here's where I found that the "internal" download method uses libxml2, which is the "libxml" from `capabilities()`: 
https://stackoverflow.com/questions/30906387/whats-the-internal-method-of-rs-download-file

https://github.com/wch/r-source/blob/8c20cb5fb31fc4cd9f674966df3463f1628a680b/src/library/base/R/unix/download.file.R#L9-L10