### PR TITLE
Build all R versions in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,10 +10,10 @@ build-images: &build-images
     - checkout
     - run:
         name: Build images
-        command: make build-all VARIANTS=$VARIANT VERSIONS="$VERSIONS"
+        command: make build-all VARIANTS=$VARIANT
     - run:
         name: Test images
-        command: make test-all VARIANTS=$VARIANT VERSIONS="$VERSIONS"
+        command: make test-all VARIANTS=$VARIANT
     - when:
         condition: << parameters.publish >>
         steps:
@@ -22,7 +22,7 @@ build-images: &build-images
               command: echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
           - run:
               name: Publish images
-              command: make push-all VARIANTS=$VARIANT VERSIONS="$VERSIONS"
+              command: make push-all VARIANTS=$VARIANT
 
 branch-master: &branch-master
   publish: true


### PR DESCRIPTION
Forked PRs aren't building anything because `$VERSIONS`is empty (I thought `VERSIONS=` would've been ignored by make, oops): https://circleci.com/gh/rstudio/r-docker/174

Rather than handling an empty `$VERSIONS` variable, I thought we could just build everything. Apparently open source projects get 4 concurrent jobs on CircleCI instead of just 1, so builds run a lot faster now. And it would be easier to not have to maintain `VERSIONS` anyway.