### PR TITLE
Add bash targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,9 @@ rebuild-$(version)-$(variant): build-base-$(variant)
 test-$(version)-$(variant):
 	docker run -it --rm -v $(PWD)/test:/test $(BASE_IMAGE):$(version)-$(variant) bash -l /test/test.sh
 
+bash-$(version)-$(variant):
+	docker run -it --rm -v $(PWD)/test:/test $(BASE_IMAGE):$(version)-$(variant) bash
+
 pull-$(version)-$(variant):
 	docker pull $(BASE_IMAGE):$(version)-$(variant)
 


### PR DESCRIPTION
Adds bash targets to `Makefile` so you can easily use something like `make bash-3.5-xenial` to get a shell.