### PR TITLE
Switch to OpenBLAS

### DIFF
--- a/3.1/centos6/Dockerfile
+++ b/3.1/centos6/Dockerfile
@@ -19,6 +19,10 @@ RUN wget -O R-${R_VERSION}.tar.gz https://cdn.rstudio.com/r/${OS_IDENTIFIER}/R-$
     ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
     rm R-${R_VERSION}.tar.gz
 
+# Configure R to use OpenBLAS
+RUN mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep && \
+    ln -s /usr/lib64/libopenblasp.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+
 # Add support for installing packages with C++11
 RUN echo $'CXX11 = g++\n\
 CXX11FLAGS = -g -O2 $(LTO)\n\

--- a/3.1/centos7/Dockerfile
+++ b/3.1/centos7/Dockerfile
@@ -19,4 +19,8 @@ RUN wget -O R-${R_VERSION}.tar.gz https://cdn.rstudio.com/r/${OS_IDENTIFIER}/R-$
     ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
     rm R-${R_VERSION}.tar.gz
 
+# Configure R to use OpenBLAS
+RUN mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep && \
+    ln -s /usr/lib64/libopenblasp.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+
 CMD ["R"]

--- a/3.1/opensuse15/Dockerfile
+++ b/3.1/opensuse15/Dockerfile
@@ -19,4 +19,8 @@ RUN wget -O R-${R_VERSION}.tar.gz https://cdn.rstudio.com/r/${OS_IDENTIFIER}/R-$
     ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
     rm R-${R_VERSION}.tar.gz
 
+# Configure R to use OpenBLAS
+RUN mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep && \
+    ln -s /usr/lib64/libopenblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+
 CMD ["R"]

--- a/3.1/opensuse42/Dockerfile
+++ b/3.1/opensuse42/Dockerfile
@@ -19,4 +19,8 @@ RUN wget -O R-${R_VERSION}.tar.gz https://cdn.rstudio.com/r/${OS_IDENTIFIER}/R-$
     ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
     rm R-${R_VERSION}.tar.gz
 
+# Configure R to use OpenBLAS
+RUN mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep && \
+    ln -s /usr/lib64/libopenblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+
 CMD ["R"]

--- a/3.2/centos6/Dockerfile
+++ b/3.2/centos6/Dockerfile
@@ -19,6 +19,10 @@ RUN wget -O R-${R_VERSION}.tar.gz https://cdn.rstudio.com/r/${OS_IDENTIFIER}/R-$
     ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
     rm R-${R_VERSION}.tar.gz
 
+# Configure R to use OpenBLAS
+RUN mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep && \
+    ln -s /usr/lib64/libopenblasp.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+
 # Add support for installing packages with C++11
 RUN echo $'CXX11 = g++\n\
 CXX11FLAGS = -g -O2 $(LTO)\n\

--- a/3.2/centos7/Dockerfile
+++ b/3.2/centos7/Dockerfile
@@ -19,4 +19,8 @@ RUN wget -O R-${R_VERSION}.tar.gz https://cdn.rstudio.com/r/${OS_IDENTIFIER}/R-$
     ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
     rm R-${R_VERSION}.tar.gz
 
+# Configure R to use OpenBLAS
+RUN mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep && \
+    ln -s /usr/lib64/libopenblasp.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+
 CMD ["R"]

--- a/3.2/opensuse15/Dockerfile
+++ b/3.2/opensuse15/Dockerfile
@@ -19,4 +19,8 @@ RUN wget -O R-${R_VERSION}.tar.gz https://cdn.rstudio.com/r/${OS_IDENTIFIER}/R-$
     ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
     rm R-${R_VERSION}.tar.gz
 
+# Configure R to use OpenBLAS
+RUN mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep && \
+    ln -s /usr/lib64/libopenblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+
 CMD ["R"]

--- a/3.2/opensuse42/Dockerfile
+++ b/3.2/opensuse42/Dockerfile
@@ -19,4 +19,8 @@ RUN wget -O R-${R_VERSION}.tar.gz https://cdn.rstudio.com/r/${OS_IDENTIFIER}/R-$
     ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
     rm R-${R_VERSION}.tar.gz
 
+# Configure R to use OpenBLAS
+RUN mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep && \
+    ln -s /usr/lib64/libopenblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+
 CMD ["R"]

--- a/3.3/centos6/Dockerfile
+++ b/3.3/centos6/Dockerfile
@@ -19,6 +19,10 @@ RUN wget -O R-${R_VERSION}.tar.gz https://cdn.rstudio.com/r/${OS_IDENTIFIER}/R-$
     ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
     rm R-${R_VERSION}.tar.gz
 
+# Configure R to use OpenBLAS
+RUN mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep && \
+    ln -s /usr/lib64/libopenblasp.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+
 # Add support for installing packages with C++11
 RUN echo $'CXX11 = g++\n\
 CXX11FLAGS = -g -O2 $(LTO)\n\

--- a/3.3/centos7/Dockerfile
+++ b/3.3/centos7/Dockerfile
@@ -19,4 +19,8 @@ RUN wget -O R-${R_VERSION}.tar.gz https://cdn.rstudio.com/r/${OS_IDENTIFIER}/R-$
     ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
     rm R-${R_VERSION}.tar.gz
 
+# Configure R to use OpenBLAS
+RUN mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep && \
+    ln -s /usr/lib64/libopenblasp.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+
 CMD ["R"]

--- a/3.3/opensuse15/Dockerfile
+++ b/3.3/opensuse15/Dockerfile
@@ -19,4 +19,8 @@ RUN wget -O R-${R_VERSION}.tar.gz https://cdn.rstudio.com/r/${OS_IDENTIFIER}/R-$
     ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
     rm R-${R_VERSION}.tar.gz
 
+# Configure R to use OpenBLAS
+RUN mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep && \
+    ln -s /usr/lib64/libopenblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+
 CMD ["R"]

--- a/3.3/opensuse42/Dockerfile
+++ b/3.3/opensuse42/Dockerfile
@@ -19,4 +19,8 @@ RUN wget -O R-${R_VERSION}.tar.gz https://cdn.rstudio.com/r/${OS_IDENTIFIER}/R-$
     ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
     rm R-${R_VERSION}.tar.gz
 
+# Configure R to use OpenBLAS
+RUN mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep && \
+    ln -s /usr/lib64/libopenblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+
 CMD ["R"]

--- a/3.4/centos6/Dockerfile
+++ b/3.4/centos6/Dockerfile
@@ -19,6 +19,10 @@ RUN wget -O R-${R_VERSION}.tar.gz https://cdn.rstudio.com/r/${OS_IDENTIFIER}/R-$
     ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
     rm R-${R_VERSION}.tar.gz
 
+# Configure R to use OpenBLAS
+RUN mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep && \
+    ln -s /usr/lib64/libopenblasp.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+
 # Add support for installing packages with C++11
 RUN echo $'CXX11 = g++\n\
 CXX11FLAGS = -g -O2 $(LTO)\n\

--- a/3.4/centos7/Dockerfile
+++ b/3.4/centos7/Dockerfile
@@ -19,4 +19,8 @@ RUN wget -O R-${R_VERSION}.tar.gz https://cdn.rstudio.com/r/${OS_IDENTIFIER}/R-$
     ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
     rm R-${R_VERSION}.tar.gz
 
+# Configure R to use OpenBLAS
+RUN mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep && \
+    ln -s /usr/lib64/libopenblasp.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+
 CMD ["R"]

--- a/3.4/opensuse15/Dockerfile
+++ b/3.4/opensuse15/Dockerfile
@@ -19,4 +19,8 @@ RUN wget -O R-${R_VERSION}.tar.gz https://cdn.rstudio.com/r/${OS_IDENTIFIER}/R-$
     ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
     rm R-${R_VERSION}.tar.gz
 
+# Configure R to use OpenBLAS
+RUN mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep && \
+    ln -s /usr/lib64/libopenblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+
 CMD ["R"]

--- a/3.4/opensuse42/Dockerfile
+++ b/3.4/opensuse42/Dockerfile
@@ -19,4 +19,8 @@ RUN wget -O R-${R_VERSION}.tar.gz https://cdn.rstudio.com/r/${OS_IDENTIFIER}/R-$
     ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
     rm R-${R_VERSION}.tar.gz
 
+# Configure R to use OpenBLAS
+RUN mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep && \
+    ln -s /usr/lib64/libopenblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+
 CMD ["R"]

--- a/3.5/centos6/Dockerfile
+++ b/3.5/centos6/Dockerfile
@@ -19,6 +19,10 @@ RUN wget -O R-${R_VERSION}.tar.gz https://cdn.rstudio.com/r/${OS_IDENTIFIER}/R-$
     ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
     rm R-${R_VERSION}.tar.gz
 
+# Configure R to use OpenBLAS
+RUN mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep && \
+    ln -s /usr/lib64/libopenblasp.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+
 # Add support for installing packages with C++11
 RUN echo $'CXX11 = g++\n\
 CXX11FLAGS = -g -O2 $(LTO)\n\

--- a/3.5/centos7/Dockerfile
+++ b/3.5/centos7/Dockerfile
@@ -19,4 +19,8 @@ RUN wget -O R-${R_VERSION}.tar.gz https://cdn.rstudio.com/r/${OS_IDENTIFIER}/R-$
     ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
     rm R-${R_VERSION}.tar.gz
 
+# Configure R to use OpenBLAS
+RUN mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep && \
+    ln -s /usr/lib64/libopenblasp.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+
 CMD ["R"]

--- a/3.5/opensuse15/Dockerfile
+++ b/3.5/opensuse15/Dockerfile
@@ -19,4 +19,8 @@ RUN wget -O R-${R_VERSION}.tar.gz https://cdn.rstudio.com/r/${OS_IDENTIFIER}/R-$
     ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
     rm R-${R_VERSION}.tar.gz
 
+# Configure R to use OpenBLAS
+RUN mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep && \
+    ln -s /usr/lib64/libopenblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+
 CMD ["R"]

--- a/3.5/opensuse42/Dockerfile
+++ b/3.5/opensuse42/Dockerfile
@@ -19,4 +19,8 @@ RUN wget -O R-${R_VERSION}.tar.gz https://cdn.rstudio.com/r/${OS_IDENTIFIER}/R-$
     ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
     rm R-${R_VERSION}.tar.gz
 
+# Configure R to use OpenBLAS
+RUN mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep && \
+    ln -s /usr/lib64/libopenblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+
 CMD ["R"]

--- a/3.6/centos6/Dockerfile
+++ b/3.6/centos6/Dockerfile
@@ -19,6 +19,10 @@ RUN wget -O R-${R_VERSION}.tar.gz https://cdn.rstudio.com/r/${OS_IDENTIFIER}/R-$
     ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
     rm R-${R_VERSION}.tar.gz
 
+# Configure R to use OpenBLAS
+RUN mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep && \
+    ln -s /usr/lib64/libopenblasp.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+
 # Add support for installing packages with C++11
 RUN echo $'CXX11 = g++\n\
 CXX11FLAGS = -g -O2 $(LTO)\n\

--- a/3.6/centos7/Dockerfile
+++ b/3.6/centos7/Dockerfile
@@ -19,4 +19,8 @@ RUN wget -O R-${R_VERSION}.tar.gz https://cdn.rstudio.com/r/${OS_IDENTIFIER}/R-$
     ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
     rm R-${R_VERSION}.tar.gz
 
+# Configure R to use OpenBLAS
+RUN mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep && \
+    ln -s /usr/lib64/libopenblasp.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+
 CMD ["R"]

--- a/3.6/opensuse15/Dockerfile
+++ b/3.6/opensuse15/Dockerfile
@@ -19,4 +19,8 @@ RUN wget -O R-${R_VERSION}.tar.gz https://cdn.rstudio.com/r/${OS_IDENTIFIER}/R-$
     ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
     rm R-${R_VERSION}.tar.gz
 
+# Configure R to use OpenBLAS
+RUN mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep && \
+    ln -s /usr/lib64/libopenblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+
 CMD ["R"]

--- a/3.6/opensuse42/Dockerfile
+++ b/3.6/opensuse42/Dockerfile
@@ -19,4 +19,8 @@ RUN wget -O R-${R_VERSION}.tar.gz https://cdn.rstudio.com/r/${OS_IDENTIFIER}/R-$
     ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
     rm R-${R_VERSION}.tar.gz
 
+# Configure R to use OpenBLAS
+RUN mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep && \
+    ln -s /usr/lib64/libopenblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+
 CMD ["R"]

--- a/Dockerfile-centos.template
+++ b/Dockerfile-centos.template
@@ -13,4 +13,8 @@ RUN wget -O R-${R_VERSION}.tar.gz https://cdn.rstudio.com/r/${OS_IDENTIFIER}/R-$
     ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
     rm R-${R_VERSION}.tar.gz
 
+# Configure R to use OpenBLAS
+RUN mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep && \
+    ln -s /usr/lib64/libopenblasp.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+
 CMD ["R"]

--- a/Dockerfile-centos6.template
+++ b/Dockerfile-centos6.template
@@ -13,6 +13,10 @@ RUN wget -O R-${R_VERSION}.tar.gz https://cdn.rstudio.com/r/${OS_IDENTIFIER}/R-$
     ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
     rm R-${R_VERSION}.tar.gz
 
+# Configure R to use OpenBLAS
+RUN mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep && \
+    ln -s /usr/lib64/libopenblasp.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+
 # Add support for installing packages with C++11
 RUN echo $'CXX11 = g++\n\
 CXX11FLAGS = -g -O2 $(LTO)\n\

--- a/Dockerfile-opensuse.template
+++ b/Dockerfile-opensuse.template
@@ -13,4 +13,8 @@ RUN wget -O R-${R_VERSION}.tar.gz https://cdn.rstudio.com/r/${OS_IDENTIFIER}/R-$
     ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
     rm R-${R_VERSION}.tar.gz
 
+# Configure R to use OpenBLAS
+RUN mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep && \
+    ln -s /usr/lib64/libopenblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+
 CMD ["R"]

--- a/base/bionic/Dockerfile
+++ b/base/bionic/Dockerfile
@@ -8,12 +8,12 @@ RUN apt-get update -qq && \
     build-essential \
     curl \
     gfortran \
-    libatlas-base-dev \
     libbz2-dev \
     libcairo2 \
     libcurl4-openssl-dev \
     libicu-dev \
     liblzma-dev \
+    libopenblas-dev \
     libpango-1.0-0 \
     libpangocairo-1.0-0 \
     libpcre3-dev \

--- a/base/centos6/Dockerfile
+++ b/base/centos6/Dockerfile
@@ -4,11 +4,8 @@ LABEL maintainer="RStudio Docker <docker@rstudio.com>"
 RUN yum -y update && \
     yum -y groupinstall "Development tools" && \
     yum -y install \
-    atlas-devel \
-    blas-devel \
     bzip2-devel \
     dejavu-sans-fonts \
-    lapack-devel \
     libcurl-devel \
     libicu-devel \
     libSM \
@@ -28,6 +25,12 @@ RUN yum -y update && \
     wget \
     xz-devel \
     zlib-devel && \
+    yum clean all
+
+# Install OpenBLAS
+RUN yum -y install epel-release && \
+    yum -y install openblas-devel && \
+    yum -y remove epel-release && \
     yum clean all
 
 # CentOS 6 ships with an older version of C++, which is too old for

--- a/base/centos7/Dockerfile
+++ b/base/centos7/Dockerfile
@@ -4,12 +4,9 @@ LABEL maintainer="RStudio Docker <docker@rstudio.com>"
 RUN yum -y update && \
     yum -y groupinstall "Development tools" && \
     yum -y install \
-    atlas-devel \
-    blas-devel \
     bzip2-devel \
     gcc \
     gcc-gfortran \
-    lapack-devel \
     libcurl-devel \
     libicu-devel \
     libSM \
@@ -29,6 +26,12 @@ RUN yum -y update && \
     wget \
     xz-devel \
     zlib-devel && \
+    yum clean all
+
+# Install OpenBLAS
+RUN yum -y install epel-release && \
+    yum -y install openblas-devel && \
+    yum -y remove epel-release && \
     yum clean all
 
 # Install TinyTeX

--- a/base/opensuse15/Dockerfile
+++ b/base/opensuse15/Dockerfile
@@ -3,15 +3,12 @@ LABEL maintainer="RStudio Docker <docker@rstudio.com>"
 
 RUN zypper --non-interactive update
 RUN zypper --non-interactive --gpg-auto-import-keys -n install \
-    atlascpp-devel \
-    blas-devel \
     fontconfig \
     gcc \
     gcc-c++ \
     gcc-fortran \
     glibc-locale \
     gzip \
-    lapack-devel \
     libbz2-devel \
     libcairo2 \
     libcurl-devel \
@@ -22,6 +19,7 @@ RUN zypper --non-interactive --gpg-auto-import-keys -n install \
     libreadline6 \
     libtiff5 \
     make \
+    openblas-devel \
     pango-tools \
     pcre-devel \
     sudo \

--- a/base/opensuse42/Dockerfile
+++ b/base/opensuse42/Dockerfile
@@ -3,14 +3,11 @@ LABEL maintainer="RStudio Docker <docker@rstudio.com>"
 
 RUN zypper --non-interactive update
 RUN zypper --non-interactive --gpg-auto-import-keys -n install \
-    atlascpp-devel \
-    blas-devel \
     fontconfig \
     gcc \
     gcc-c++ \
     gcc-fortran \
     glibc-locale \
-    lapack-devel \
     libbz2-devel \
     libcairo2 \
     libcurl-devel \
@@ -20,6 +17,7 @@ RUN zypper --non-interactive --gpg-auto-import-keys -n install \
     libjpeg62 \
     libtiff5 \
     make \
+    openblas-devel \
     pango-tools \
     pcre-devel \
     sudo \

--- a/base/xenial/Dockerfile
+++ b/base/xenial/Dockerfile
@@ -7,12 +7,12 @@ RUN apt-get update -qq && \
     build-essential \
     curl \
     gfortran \
-    libatlas-base-dev \
     libbz2-dev \
     libcairo2 \
     libcurl4-openssl-dev \
     libicu-dev \
     liblzma-dev \
+    libopenblas-dev \
     libpango-1.0-0 \
     libpangocairo-1.0-0 \
     libpcre3-dev \

--- a/test/test.R
+++ b/test/test.R
@@ -88,3 +88,8 @@ output <- system2("Rscript", "-e 'help(stats)'", stdout = TRUE)
 if (length(output) == 0) {
   stop("failed to display help pages; check that a pager is configured properly")
 }
+
+# Smoke test BLAS/LAPACK functionality. R may start just fine with an incompatible
+# BLAS/LAPACK library, and only fail when calling a BLAS or LAPACK routine.
+stopifnot(identical(crossprod(matrix(1)), matrix(1)))
+stopifnot(identical(chol(matrix(1)), matrix(1)))

--- a/test/test.sh
+++ b/test/test.sh
@@ -6,10 +6,13 @@ DIR="$(dirname "$(readlink -f "$BASH_SOURCE")")"
 R --version
 Rscript -e 'sessionInfo()'
 
-# R devel dependencies
+# List R devel dependencies
 gcc --version
 g++ --version
 gfortran --version
+
+# List shared library dependencies (e.g. BLAS/LAPACK)
+ldd $(R RHOME)/lib/libR.so
 
 # Install a package with C and Fortran code, R devel libs
 R CMD INSTALL $DIR/testpkg --clean

--- a/test/test.sh
+++ b/test/test.sh
@@ -12,7 +12,7 @@ g++ --version
 gfortran --version
 
 # List shared library dependencies (e.g. BLAS/LAPACK)
-ldd $(R RHOME)/lib/libR.so
+LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(R RHOME)/lib ldd $(R RHOME)/lib/libR.so
 
 # Install a package with C and Fortran code, R devel libs
 R CMD INSTALL $DIR/testpkg --clean


### PR DESCRIPTION
**Note:** can't merge this until the R binaries have been updated in https://github.com/rstudio/r-builds/pull/11

This switches the BLAS libraries to multithreaded OpenBLAS. Once the R binaries have been updated, the test output for R 3.4+ builds should show "libopenblasp" being used in the session info:
```r
+ Rscript -e 'sessionInfo()'
R version 3.4.4 (2018-03-15)
Platform: x86_64-pc-linux-gnu (64-bit)
Running under: CentOS Linux 7 (Core)

Matrix products: default
BLAS/LAPACK: /usr/lib64/libopenblasp-r0.3.3.so
```

R 3.3 and below don't show the BLAS library in sessionInfo, but you should at least be able to see that R is linked against shared BLAS (libRblas.so) on CentOS/openSUSE, and the generic external libblas.so.3 on Ubuntu:
```sh
# CentOS/openSUSE
+ ldd /opt/R/3.2.5/lib/R/lib/libR.so
	libRblas.so => /opt/R/3.2.5/lib/R/lib/libRblas.so (0x00007f3e74e78000)

# Ubuntu
+ ldd /opt/R/3.1.3/lib/R/lib/libR.so
	libblas.so.3 => /usr/lib/libblas.so.3 (0x00007fd69efd6000)
	libopenblas.so.0 => /usr/lib/libopenblas.so.0 (0x00007fd69b3c6000)
```
