### PR TITLE
Install R from rpm on CentOS 7

### DIFF
--- a/3.1/centos7/Dockerfile
+++ b/3.1/centos7/Dockerfile
@@ -11,16 +11,14 @@ ARG R_VERSION=3.1.3
 ARG OS_IDENTIFIER=centos-7
 
 # Install R
-RUN wget -O R-${R_VERSION}.tar.gz https://cdn.rstudio.com/r/${OS_IDENTIFIER}/R-${R_VERSION}-${OS_IDENTIFIER}.tar.gz && \
-    mkdir -p /opt/R && \
-    tar zx -C /opt/R -f ./R-${R_VERSION}.tar.gz && \
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    yum -y install epel-release && \
+    yum -y install ./R-${R_VERSION}-1-1.x86_64.rpm && \
     ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
     ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
     ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
-    rm R-${R_VERSION}.tar.gz
-
-# Configure R to use OpenBLAS
-RUN mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep && \
-    ln -s /usr/lib64/libopenblasp.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    yum -y remove epel-release && \
+    yum clean all
 
 CMD ["R"]

--- a/3.2/centos7/Dockerfile
+++ b/3.2/centos7/Dockerfile
@@ -11,16 +11,14 @@ ARG R_VERSION=3.2.5
 ARG OS_IDENTIFIER=centos-7
 
 # Install R
-RUN wget -O R-${R_VERSION}.tar.gz https://cdn.rstudio.com/r/${OS_IDENTIFIER}/R-${R_VERSION}-${OS_IDENTIFIER}.tar.gz && \
-    mkdir -p /opt/R && \
-    tar zx -C /opt/R -f ./R-${R_VERSION}.tar.gz && \
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    yum -y install epel-release && \
+    yum -y install ./R-${R_VERSION}-1-1.x86_64.rpm && \
     ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
     ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
     ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
-    rm R-${R_VERSION}.tar.gz
-
-# Configure R to use OpenBLAS
-RUN mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep && \
-    ln -s /usr/lib64/libopenblasp.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    yum -y remove epel-release && \
+    yum clean all
 
 CMD ["R"]

--- a/3.3/centos7/Dockerfile
+++ b/3.3/centos7/Dockerfile
@@ -11,16 +11,14 @@ ARG R_VERSION=3.3.3
 ARG OS_IDENTIFIER=centos-7
 
 # Install R
-RUN wget -O R-${R_VERSION}.tar.gz https://cdn.rstudio.com/r/${OS_IDENTIFIER}/R-${R_VERSION}-${OS_IDENTIFIER}.tar.gz && \
-    mkdir -p /opt/R && \
-    tar zx -C /opt/R -f ./R-${R_VERSION}.tar.gz && \
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    yum -y install epel-release && \
+    yum -y install ./R-${R_VERSION}-1-1.x86_64.rpm && \
     ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
     ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
     ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
-    rm R-${R_VERSION}.tar.gz
-
-# Configure R to use OpenBLAS
-RUN mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep && \
-    ln -s /usr/lib64/libopenblasp.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    yum -y remove epel-release && \
+    yum clean all
 
 CMD ["R"]

--- a/3.4/centos7/Dockerfile
+++ b/3.4/centos7/Dockerfile
@@ -11,16 +11,14 @@ ARG R_VERSION=3.4.4
 ARG OS_IDENTIFIER=centos-7
 
 # Install R
-RUN wget -O R-${R_VERSION}.tar.gz https://cdn.rstudio.com/r/${OS_IDENTIFIER}/R-${R_VERSION}-${OS_IDENTIFIER}.tar.gz && \
-    mkdir -p /opt/R && \
-    tar zx -C /opt/R -f ./R-${R_VERSION}.tar.gz && \
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    yum -y install epel-release && \
+    yum -y install ./R-${R_VERSION}-1-1.x86_64.rpm && \
     ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
     ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
     ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
-    rm R-${R_VERSION}.tar.gz
-
-# Configure R to use OpenBLAS
-RUN mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep && \
-    ln -s /usr/lib64/libopenblasp.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    yum -y remove epel-release && \
+    yum clean all
 
 CMD ["R"]

--- a/3.5/centos7/Dockerfile
+++ b/3.5/centos7/Dockerfile
@@ -11,16 +11,14 @@ ARG R_VERSION=3.5.3
 ARG OS_IDENTIFIER=centos-7
 
 # Install R
-RUN wget -O R-${R_VERSION}.tar.gz https://cdn.rstudio.com/r/${OS_IDENTIFIER}/R-${R_VERSION}-${OS_IDENTIFIER}.tar.gz && \
-    mkdir -p /opt/R && \
-    tar zx -C /opt/R -f ./R-${R_VERSION}.tar.gz && \
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    yum -y install epel-release && \
+    yum -y install ./R-${R_VERSION}-1-1.x86_64.rpm && \
     ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
     ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
     ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
-    rm R-${R_VERSION}.tar.gz
-
-# Configure R to use OpenBLAS
-RUN mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep && \
-    ln -s /usr/lib64/libopenblasp.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    yum -y remove epel-release && \
+    yum clean all
 
 CMD ["R"]

--- a/3.6/centos7/Dockerfile
+++ b/3.6/centos7/Dockerfile
@@ -11,16 +11,14 @@ ARG R_VERSION=3.6.1
 ARG OS_IDENTIFIER=centos-7
 
 # Install R
-RUN wget -O R-${R_VERSION}.tar.gz https://cdn.rstudio.com/r/${OS_IDENTIFIER}/R-${R_VERSION}-${OS_IDENTIFIER}.tar.gz && \
-    mkdir -p /opt/R && \
-    tar zx -C /opt/R -f ./R-${R_VERSION}.tar.gz && \
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    yum -y install epel-release && \
+    yum -y install ./R-${R_VERSION}-1-1.x86_64.rpm && \
     ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
     ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
     ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
-    rm R-${R_VERSION}.tar.gz
-
-# Configure R to use OpenBLAS
-RUN mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep && \
-    ln -s /usr/lib64/libopenblasp.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    yum -y remove epel-release && \
+    yum clean all
 
 CMD ["R"]

--- a/Dockerfile-centos.template
+++ b/Dockerfile-centos.template
@@ -5,16 +5,14 @@ ARG R_VERSION=%%R_VERSION%%
 ARG OS_IDENTIFIER=%%OS_IDENTIFIER%%
 
 # Install R
-RUN wget -O R-${R_VERSION}.tar.gz https://cdn.rstudio.com/r/${OS_IDENTIFIER}/R-${R_VERSION}-${OS_IDENTIFIER}.tar.gz && \
-    mkdir -p /opt/R && \
-    tar zx -C /opt/R -f ./R-${R_VERSION}.tar.gz && \
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    yum -y install epel-release && \
+    yum -y install ./R-${R_VERSION}-1-1.x86_64.rpm && \
     ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
     ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
     ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
-    rm R-${R_VERSION}.tar.gz
-
-# Configure R to use OpenBLAS
-RUN mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep && \
-    ln -s /usr/lib64/libopenblasp.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    yum -y remove epel-release && \
+    yum clean all
 
 CMD ["R"]

--- a/base/centos7/Dockerfile
+++ b/base/centos7/Dockerfile
@@ -2,36 +2,12 @@ FROM centos:centos7
 LABEL maintainer="RStudio Docker <docker@rstudio.com>"
 
 RUN yum -y update && \
-    yum -y groupinstall "Development tools" && \
     yum -y install \
-    bzip2-devel \
-    gcc \
-    gcc-gfortran \
-    libcurl-devel \
-    libicu-devel \
-    libSM \
-    libtiff \
-    libXmu \
-    libXt \
-    make \
-    pango \
-    pcre-devel \
-    pcre2-devel \
+    fontconfig \
     perl-Digest-MD5 \
     sudo \
-    tcl \
-    tk \
-    tre \
     vim \
-    wget \
-    xz-devel \
-    zlib-devel && \
-    yum clean all
-
-# Install OpenBLAS
-RUN yum -y install epel-release && \
-    yum -y install openblas-devel && \
-    yum -y remove epel-release && \
+    wget && \
     yum clean all
 
 # Install TinyTeX


### PR DESCRIPTION
Diff of the image before and after:
```sh
$ container-diff diff -n daemon://rstudio/r-base:3.5-centos7 daemon://r-base-rpm:3.5-centos7 --type=size --type=rpm

-----RPM-----

Packages found only in rstudio/r-base:3.5-centos7:
NAME                         VERSION             SIZE
-apr                         1.4.8               221.4K
-apr-util                    1.5.2               194.1K
-autoconf                    2.69                2.2M
-automake                    1.13.4              1.7M
-avahi-libs                  0.6.31              120.9K
-bison                       3.0.4               2.1M
-boost-date-time             1.53.0              136.4K
-boost-system                1.53.0              31.8K
-boost-thread                1.53.0              93.4K
-byacc                       1.9.20130304        132K
-bzip2                       1.0.6               81.8K
-cscope                      15.8                917.7K
-ctags                       5.8                 351.3K
-diffstat                    1.57                52.8K
-doxygen                     1.8.5               14.7M
-dwz                         0.11                219.8K
-dyninst                     9.3.1               12.4M
-efivar-libs                 36                  246.2K
-elfutils                    0.172               792.8K
-emacs-filesystem            24.3                0
-file                        5.11                65.9K
-fipscheck                   1.4.1               37.9K
-fipscheck-lib               1.4.1               11.2K
-flex                        2.5.37              739.7K
-gdb                         7.6.1               7M
-gettext                     0.19.8.1            4.8M
-gettext-common-devel        0.19.8.1            388.6K
-gettext-devel               0.19.8.1            1.4M
-gettext-libs                0.19.8.1            1.5M
-git                         1.8.3.1             22.2M
-gnutls                      3.3.29              2M
-indent                      2.2.11              350.7K
-intltool                    0.50.2              166.1K
-kernel-debug-devel          3.10.0              37.5M
-less                        458                 210.3K
-libcroco                    0.6.12              313.4K
-libdwarf                    20130207            284.8K
-libedit                     3.0                 238.5K
-libmodman                   2.0.1               57.5K
-libproxy                    0.4.11              160.2K
-libtool                     2.4.2               2.2M
-libunistring                0.9.3               1.1M
-m4                          1.4.16              513.4K
-mokutil                     15                  81.6K
-neon                        0.30.0              554.5K
-nettle                      2.7.1               747.1K
-openssh                     7.4p1               1.9M
-openssh-clients             7.4p1               2.5M
-pakchois                    0.4                 28.8K
-patch                       2.7.1               210.4K
-patchutils                  0.3.3               254K
-perl-Data-Dumper            2.145               97K
-perl-Error                  0.17020             48.8K
-perl-Git                    1.8.3.1             57.2K
-perl-TermReadKey            2.30                58.6K
-perl-Test-Harness           3.28                593K
-perl-Thread-Queue           3.02                27K
-perl-XML-Parser             2.41                627.9K
-perl-srpm-macros            1                   794B
-rcs                         5.9.0               610.1K
-redhat-rpm-config           9.1.0               170.5K
-rpm-build                   4.11.3              320.7K
-rpm-sign                    4.11.3              17K
-rsync                       3.1.2               815.1K
-subversion                  1.7.14              4.6M
-subversion-libs             1.7.14              2.5M
-swig                        2.0.10              4.7M
-systemd-sysv                219                 3.9K
-systemtap                   3.3                 201.7K
-systemtap-client            3.3                 9.7M
-systemtap-devel             3.3                 7.5M
-systemtap-runtime           3.3                 1.1M
-trousers                    0.3.14              817.3K
-unzip                       6.0                 365.2K
-zip                         3.0                 796.1K

Packages found only in r-base-rpm:3.5-centos7:
NAME               VERSION        SIZE
-R-3.5.3           1              95.1M
-tre               0.8.0          63.9K
-tre-common        0.8.0          81K

Version differences: None

-----Size-----

Image size difference between rstudio/r-base:3.5-centos7 and r-base-rpm:3.5-centos7:
SIZE1        SIZE2
1.4G         1.2G
```

Most of the differences were from removing the development tools groupinstall, I think. Looks like tre wasn't getting installed before, since it's apparently only available from EPEL. Do you know what it's used for? At least it doesn't seem to be a strict runtime dependency.