### PR TITLE
Install R from rpm on openSUSE

### DIFF
--- a/3.1/opensuse15/Dockerfile
+++ b/3.1/opensuse15/Dockerfile
@@ -11,16 +11,12 @@ ARG R_VERSION=3.1.3
 ARG OS_IDENTIFIER=opensuse-15
 
 # Install R
-RUN wget -O R-${R_VERSION}.tar.gz https://cdn.rstudio.com/r/${OS_IDENTIFIER}/R-${R_VERSION}-${OS_IDENTIFIER}.tar.gz && \
-    mkdir -p /opt/R && \
-    tar zx -C /opt/R -f ./R-${R_VERSION}.tar.gz && \
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper --non-interactive --no-gpg-checks install ./R-${R_VERSION}-1-1.x86_64.rpm && \
     ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
     ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
     ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
-    rm R-${R_VERSION}.tar.gz
-
-# Configure R to use OpenBLAS
-RUN mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep && \
-    ln -s /usr/lib64/libopenblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper clean --all
 
 CMD ["R"]

--- a/3.1/opensuse42/Dockerfile
+++ b/3.1/opensuse42/Dockerfile
@@ -11,16 +11,12 @@ ARG R_VERSION=3.1.3
 ARG OS_IDENTIFIER=opensuse-42
 
 # Install R
-RUN wget -O R-${R_VERSION}.tar.gz https://cdn.rstudio.com/r/${OS_IDENTIFIER}/R-${R_VERSION}-${OS_IDENTIFIER}.tar.gz && \
-    mkdir -p /opt/R && \
-    tar zx -C /opt/R -f ./R-${R_VERSION}.tar.gz && \
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper --non-interactive --no-gpg-checks install ./R-${R_VERSION}-1-1.x86_64.rpm && \
     ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
     ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
     ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
-    rm R-${R_VERSION}.tar.gz
-
-# Configure R to use OpenBLAS
-RUN mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep && \
-    ln -s /usr/lib64/libopenblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper clean --all
 
 CMD ["R"]

--- a/3.2/opensuse15/Dockerfile
+++ b/3.2/opensuse15/Dockerfile
@@ -11,16 +11,12 @@ ARG R_VERSION=3.2.5
 ARG OS_IDENTIFIER=opensuse-15
 
 # Install R
-RUN wget -O R-${R_VERSION}.tar.gz https://cdn.rstudio.com/r/${OS_IDENTIFIER}/R-${R_VERSION}-${OS_IDENTIFIER}.tar.gz && \
-    mkdir -p /opt/R && \
-    tar zx -C /opt/R -f ./R-${R_VERSION}.tar.gz && \
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper --non-interactive --no-gpg-checks install ./R-${R_VERSION}-1-1.x86_64.rpm && \
     ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
     ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
     ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
-    rm R-${R_VERSION}.tar.gz
-
-# Configure R to use OpenBLAS
-RUN mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep && \
-    ln -s /usr/lib64/libopenblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper clean --all
 
 CMD ["R"]

--- a/3.2/opensuse42/Dockerfile
+++ b/3.2/opensuse42/Dockerfile
@@ -11,16 +11,12 @@ ARG R_VERSION=3.2.5
 ARG OS_IDENTIFIER=opensuse-42
 
 # Install R
-RUN wget -O R-${R_VERSION}.tar.gz https://cdn.rstudio.com/r/${OS_IDENTIFIER}/R-${R_VERSION}-${OS_IDENTIFIER}.tar.gz && \
-    mkdir -p /opt/R && \
-    tar zx -C /opt/R -f ./R-${R_VERSION}.tar.gz && \
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper --non-interactive --no-gpg-checks install ./R-${R_VERSION}-1-1.x86_64.rpm && \
     ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
     ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
     ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
-    rm R-${R_VERSION}.tar.gz
-
-# Configure R to use OpenBLAS
-RUN mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep && \
-    ln -s /usr/lib64/libopenblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper clean --all
 
 CMD ["R"]

--- a/3.3/opensuse15/Dockerfile
+++ b/3.3/opensuse15/Dockerfile
@@ -11,16 +11,12 @@ ARG R_VERSION=3.3.3
 ARG OS_IDENTIFIER=opensuse-15
 
 # Install R
-RUN wget -O R-${R_VERSION}.tar.gz https://cdn.rstudio.com/r/${OS_IDENTIFIER}/R-${R_VERSION}-${OS_IDENTIFIER}.tar.gz && \
-    mkdir -p /opt/R && \
-    tar zx -C /opt/R -f ./R-${R_VERSION}.tar.gz && \
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper --non-interactive --no-gpg-checks install ./R-${R_VERSION}-1-1.x86_64.rpm && \
     ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
     ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
     ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
-    rm R-${R_VERSION}.tar.gz
-
-# Configure R to use OpenBLAS
-RUN mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep && \
-    ln -s /usr/lib64/libopenblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper clean --all
 
 CMD ["R"]

--- a/3.3/opensuse42/Dockerfile
+++ b/3.3/opensuse42/Dockerfile
@@ -11,16 +11,12 @@ ARG R_VERSION=3.3.3
 ARG OS_IDENTIFIER=opensuse-42
 
 # Install R
-RUN wget -O R-${R_VERSION}.tar.gz https://cdn.rstudio.com/r/${OS_IDENTIFIER}/R-${R_VERSION}-${OS_IDENTIFIER}.tar.gz && \
-    mkdir -p /opt/R && \
-    tar zx -C /opt/R -f ./R-${R_VERSION}.tar.gz && \
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper --non-interactive --no-gpg-checks install ./R-${R_VERSION}-1-1.x86_64.rpm && \
     ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
     ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
     ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
-    rm R-${R_VERSION}.tar.gz
-
-# Configure R to use OpenBLAS
-RUN mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep && \
-    ln -s /usr/lib64/libopenblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper clean --all
 
 CMD ["R"]

--- a/3.4/opensuse15/Dockerfile
+++ b/3.4/opensuse15/Dockerfile
@@ -11,16 +11,12 @@ ARG R_VERSION=3.4.4
 ARG OS_IDENTIFIER=opensuse-15
 
 # Install R
-RUN wget -O R-${R_VERSION}.tar.gz https://cdn.rstudio.com/r/${OS_IDENTIFIER}/R-${R_VERSION}-${OS_IDENTIFIER}.tar.gz && \
-    mkdir -p /opt/R && \
-    tar zx -C /opt/R -f ./R-${R_VERSION}.tar.gz && \
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper --non-interactive --no-gpg-checks install ./R-${R_VERSION}-1-1.x86_64.rpm && \
     ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
     ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
     ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
-    rm R-${R_VERSION}.tar.gz
-
-# Configure R to use OpenBLAS
-RUN mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep && \
-    ln -s /usr/lib64/libopenblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper clean --all
 
 CMD ["R"]

--- a/3.4/opensuse42/Dockerfile
+++ b/3.4/opensuse42/Dockerfile
@@ -11,16 +11,12 @@ ARG R_VERSION=3.4.4
 ARG OS_IDENTIFIER=opensuse-42
 
 # Install R
-RUN wget -O R-${R_VERSION}.tar.gz https://cdn.rstudio.com/r/${OS_IDENTIFIER}/R-${R_VERSION}-${OS_IDENTIFIER}.tar.gz && \
-    mkdir -p /opt/R && \
-    tar zx -C /opt/R -f ./R-${R_VERSION}.tar.gz && \
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper --non-interactive --no-gpg-checks install ./R-${R_VERSION}-1-1.x86_64.rpm && \
     ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
     ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
     ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
-    rm R-${R_VERSION}.tar.gz
-
-# Configure R to use OpenBLAS
-RUN mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep && \
-    ln -s /usr/lib64/libopenblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper clean --all
 
 CMD ["R"]

--- a/3.5/opensuse15/Dockerfile
+++ b/3.5/opensuse15/Dockerfile
@@ -11,16 +11,12 @@ ARG R_VERSION=3.5.3
 ARG OS_IDENTIFIER=opensuse-15
 
 # Install R
-RUN wget -O R-${R_VERSION}.tar.gz https://cdn.rstudio.com/r/${OS_IDENTIFIER}/R-${R_VERSION}-${OS_IDENTIFIER}.tar.gz && \
-    mkdir -p /opt/R && \
-    tar zx -C /opt/R -f ./R-${R_VERSION}.tar.gz && \
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper --non-interactive --no-gpg-checks install ./R-${R_VERSION}-1-1.x86_64.rpm && \
     ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
     ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
     ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
-    rm R-${R_VERSION}.tar.gz
-
-# Configure R to use OpenBLAS
-RUN mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep && \
-    ln -s /usr/lib64/libopenblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper clean --all
 
 CMD ["R"]

--- a/3.5/opensuse42/Dockerfile
+++ b/3.5/opensuse42/Dockerfile
@@ -11,16 +11,12 @@ ARG R_VERSION=3.5.3
 ARG OS_IDENTIFIER=opensuse-42
 
 # Install R
-RUN wget -O R-${R_VERSION}.tar.gz https://cdn.rstudio.com/r/${OS_IDENTIFIER}/R-${R_VERSION}-${OS_IDENTIFIER}.tar.gz && \
-    mkdir -p /opt/R && \
-    tar zx -C /opt/R -f ./R-${R_VERSION}.tar.gz && \
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper --non-interactive --no-gpg-checks install ./R-${R_VERSION}-1-1.x86_64.rpm && \
     ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
     ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
     ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
-    rm R-${R_VERSION}.tar.gz
-
-# Configure R to use OpenBLAS
-RUN mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep && \
-    ln -s /usr/lib64/libopenblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper clean --all
 
 CMD ["R"]

--- a/3.6/opensuse15/Dockerfile
+++ b/3.6/opensuse15/Dockerfile
@@ -11,16 +11,12 @@ ARG R_VERSION=3.6.1
 ARG OS_IDENTIFIER=opensuse-15
 
 # Install R
-RUN wget -O R-${R_VERSION}.tar.gz https://cdn.rstudio.com/r/${OS_IDENTIFIER}/R-${R_VERSION}-${OS_IDENTIFIER}.tar.gz && \
-    mkdir -p /opt/R && \
-    tar zx -C /opt/R -f ./R-${R_VERSION}.tar.gz && \
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper --non-interactive --no-gpg-checks install ./R-${R_VERSION}-1-1.x86_64.rpm && \
     ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
     ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
     ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
-    rm R-${R_VERSION}.tar.gz
-
-# Configure R to use OpenBLAS
-RUN mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep && \
-    ln -s /usr/lib64/libopenblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper clean --all
 
 CMD ["R"]

--- a/3.6/opensuse42/Dockerfile
+++ b/3.6/opensuse42/Dockerfile
@@ -11,16 +11,12 @@ ARG R_VERSION=3.6.1
 ARG OS_IDENTIFIER=opensuse-42
 
 # Install R
-RUN wget -O R-${R_VERSION}.tar.gz https://cdn.rstudio.com/r/${OS_IDENTIFIER}/R-${R_VERSION}-${OS_IDENTIFIER}.tar.gz && \
-    mkdir -p /opt/R && \
-    tar zx -C /opt/R -f ./R-${R_VERSION}.tar.gz && \
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper --non-interactive --no-gpg-checks install ./R-${R_VERSION}-1-1.x86_64.rpm && \
     ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
     ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
     ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
-    rm R-${R_VERSION}.tar.gz
-
-# Configure R to use OpenBLAS
-RUN mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep && \
-    ln -s /usr/lib64/libopenblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper clean --all
 
 CMD ["R"]

--- a/Dockerfile-opensuse.template
+++ b/Dockerfile-opensuse.template
@@ -5,16 +5,12 @@ ARG R_VERSION=%%R_VERSION%%
 ARG OS_IDENTIFIER=%%OS_IDENTIFIER%%
 
 # Install R
-RUN wget -O R-${R_VERSION}.tar.gz https://cdn.rstudio.com/r/${OS_IDENTIFIER}/R-${R_VERSION}-${OS_IDENTIFIER}.tar.gz && \
-    mkdir -p /opt/R && \
-    tar zx -C /opt/R -f ./R-${R_VERSION}.tar.gz && \
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper --non-interactive --no-gpg-checks install ./R-${R_VERSION}-1-1.x86_64.rpm && \
     ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
     ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
     ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
-    rm R-${R_VERSION}.tar.gz
-
-# Configure R to use OpenBLAS
-RUN mv /opt/R/${R_VERSION}/lib/R/lib/libRblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so.keep && \
-    ln -s /usr/lib64/libopenblas.so /opt/R/${R_VERSION}/lib/R/lib/libRblas.so
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper clean --all
 
 CMD ["R"]

--- a/base/opensuse15/Dockerfile
+++ b/base/opensuse15/Dockerfile
@@ -2,38 +2,13 @@ FROM opensuse/leap:15.0
 LABEL maintainer="RStudio Docker <docker@rstudio.com>"
 
 RUN zypper --non-interactive update
-RUN zypper --non-interactive --gpg-auto-import-keys -n install \
+RUN zypper --non-interactive --gpg-auto-import-keys install \
     fontconfig \
-    gcc \
-    gcc-c++ \
-    gcc-fortran \
-    glibc-locale \
     gzip \
-    libbz2-devel \
-    libcairo2 \
-    libcurl-devel \
-    libfreetype6 \
-    libgomp1 \
-    libicu-devel \
-    libjpeg62 \
-    libreadline6 \
-    libtiff5 \
-    make \
-    openblas-devel \
-    pango-tools \
-    pcre-devel \
     sudo \
     tar \
-    tcl \
-    tk \
     vim \
     wget \
-    xdg-utils \
-    xorg-x11 \
-    xorg-x11-fonts-100dpi \
-    xorg-x11-fonts-75dpi \
-    xz-devel \
-    zlib-devel \
     && zypper clean --all
 
 # Install TinyTeX

--- a/base/opensuse42/Dockerfile
+++ b/base/opensuse42/Dockerfile
@@ -2,36 +2,12 @@ FROM opensuse/leap:42.3
 LABEL maintainer="RStudio Docker <docker@rstudio.com>"
 
 RUN zypper --non-interactive update
-RUN zypper --non-interactive --gpg-auto-import-keys -n install \
+RUN zypper --non-interactive --gpg-auto-import-keys install \
     fontconfig \
-    gcc \
-    gcc-c++ \
-    gcc-fortran \
-    glibc-locale \
-    libbz2-devel \
-    libcairo2 \
-    libcurl-devel \
-    libfreetype6 \
-    libgomp1 \
-    libicu-devel \
-    libjpeg62 \
-    libtiff5 \
-    make \
-    openblas-devel \
-    pango-tools \
-    pcre-devel \
     sudo \
     tar \
-    tcl \
-    tk \
     vim \
     wget \
-    xdg-utils \
-    xorg-x11 \
-    xorg-x11-fonts-100dpi \
-    xorg-x11-fonts-75dpi \
-    xz-devel \
-    zlib-devel \
     && zypper clean --all
 
 # Install TinyTeX


### PR DESCRIPTION
Image diff for opensuse42:
```
$ container-diff diff -n daemon://rstudio/r-base:3.5-opensuse42 daemon://r-base-rpm:3.5-opensuse42 --type=size --type=rpm
-----RPM-----

Packages found only in rstudio/r-base:3.5-opensuse42:
NAME                      VERSION         SIZE
-perl-Net-DBus            1.0.0           569K
-perl-X11-Protocol        0.56            288.7K
-perl-XML-Parser          2.41            630.2K
-perl-XML-Twig            3.44            1.1M
-xdg-utils                20160610        341.7K

Packages found only in r-base-rpm:3.5-opensuse42:
NAME            VERSION        SIZE
-R-3.5.3        1              92.3M
-unzip          6.00           263K
-zip            3.0            790.5K

Version differences: None

-----Size-----

Image size difference between rstudio/r-base:3.5-opensuse42 and r-base-rpm:3.5-opensuse42:
SIZE1        SIZE2
1.5G         1.5G
```

The new image doesn't have xdg-utils, but we left it out of the other OSs too.

and opensuse15:
```
$ container-diff diff -n daemon://rstudio/r-base:3.5-opensuse15 daemon://r-base-rpm:3.5-opensuse15 --type=size --type=rpm
-----RPM-----

Packages found only in rstudio/r-base:3.5-opensuse15:
NAME                           VERSION         SIZE
-expat                         2.2.5           219.4K
-perl-CPAN-Changes             0.400002        56.1K
-perl-Devel-Symdump            2.18            30K
-perl-Net-DBus                 1.1.0           571.2K
-perl-Pod-Coverage             0.23            31.2K
-perl-Test-Pod                 1.51            19.1K
-perl-Test-Pod-Coverage        1.10            15.1K
-perl-X11-Protocol             0.56            277.4K
-perl-XML-Parser               2.44            1.4M
-perl-XML-Twig                 3.52            1.1M
-xdg-utils                     20170508        344.9K

Packages found only in r-base-rpm:3.5-opensuse15:
NAME            VERSION        SIZE
-R-3.5.3        1              84.3M
-unzip          6.00           262.8K
-zip            3.0            838.4K

Version differences: None

-----Size-----

Image size difference between rstudio/r-base:3.5-opensuse15 and r-base-rpm:3.5-opensuse15:
SIZE1        SIZE2
1.5G         1.5G
```