### PR TITLE
Set the TZ environment variable

### DIFF
--- a/base/bionic/Dockerfile
+++ b/base/bionic/Dockerfile
@@ -38,3 +38,6 @@ RUN mkdir -p /opt/pandoc && \
 
 # Set default locale
 ENV LANG C.UTF-8
+
+# Set default timezone
+ENV TZ UTC

--- a/base/centos6/Dockerfile
+++ b/base/centos6/Dockerfile
@@ -48,3 +48,6 @@ RUN mkdir -p /opt/pandoc && \
 
 # Set default locale
 ENV LANG en_US.UTF-8
+
+# Set default timezone
+ENV TZ UTC

--- a/base/centos7/Dockerfile
+++ b/base/centos7/Dockerfile
@@ -28,3 +28,6 @@ RUN mkdir -p /opt/pandoc && \
 
 # Set default locale
 ENV LANG en_US.UTF-8
+
+# Set default timezone
+ENV TZ UTC

--- a/base/opensuse15/Dockerfile
+++ b/base/opensuse15/Dockerfile
@@ -29,3 +29,6 @@ RUN mkdir -p /opt/pandoc && \
 
 # Set default locale
 ENV LANG C.UTF-8
+
+# Set default timezone
+ENV TZ UTC

--- a/base/opensuse42/Dockerfile
+++ b/base/opensuse42/Dockerfile
@@ -28,3 +28,6 @@ RUN mkdir -p /opt/pandoc && \
 
 # Set default locale
 ENV LANG C.UTF-8
+
+# Set default timezone
+ENV TZ UTC

--- a/base/xenial/Dockerfile
+++ b/base/xenial/Dockerfile
@@ -37,3 +37,6 @@ RUN mkdir -p /opt/pandoc && \
 
 # Set default locale
 ENV LANG C.UTF-8
+
+# Set default timezone
+ENV TZ UTC

--- a/test/test.R
+++ b/test/test.R
@@ -15,6 +15,15 @@ if (length(OlsonNames()) == 0) {
   stop("Time zone database not found")
 }
 
+# Check that TZ is configured properly
+# https://github.com/rstudio/r-docker/issues/46
+tryCatch(Sys.timezone(), warning = function(w) {
+  stop("Sys.timezone() returned warning: ", w)
+})
+if (!identical(Sys.timezone(), "UTC")) {
+  stop("TZ not set to UTC")
+}
+
 # Check that we're in a UTF-8 native locale (e.g. LANG=C.UTF-8 or LANG=en_US.UTF-8)
 # https://stat.ethz.ch/R-manual/R-devel/library/base/html/locales.html
 if (!l10n_info()[["UTF-8"]]) {


### PR DESCRIPTION
Set `TZ=UTC` to prevent a couple issues with using `Sys.timezone()`:
- `Sys.timezone()` returns a warning on R >= 3.4 with `timedatectl` present
- `Sys.timezone()` returns a warning on R >= 3.4 with CentOS 6
- `Sys.timezone()` returns NA on R <= 3.3 with CentOS 6

Resolves https://github.com/rstudio/r-docker/issues/46