### PR TITLE
Add Ubuntu 20.04 Focal

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,10 @@ jobs:
     <<: *build-images
     environment:
       VARIANT: bionic
+  focal:
+    <<: *build-images
+    environment:
+      VARIANT: focal
   centos6:
     <<: *build-images
     environment:
@@ -75,6 +79,8 @@ workflows:
           <<: *branch-default
       - bionic:
           <<: *branch-default
+      - focal:
+          <<: *branch-default
       - centos6:
           <<: *branch-default
       - centos7:
@@ -90,6 +96,8 @@ workflows:
       - xenial:
           <<: *branch-master
       - bionic:
+          <<: *branch-master
+      - focal:
           <<: *branch-master
       - centos6:
           <<: *branch-master

--- a/3.1/focal/Dockerfile
+++ b/3.1/focal/Dockerfile
@@ -1,0 +1,23 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:focal
+
+ARG R_VERSION=3.1.3
+ARG OS_IDENTIFIER=ubuntu-2004
+
+# Install R
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/r-${R_VERSION}_1_amd64.deb && \
+    apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -f -y ./r-${R_VERSION}_1_amd64.deb && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm r-${R_VERSION}_1_amd64.deb && \
+    rm -rf /var/lib/apt/lists/*
+
+CMD ["R"]

--- a/3.1/focal/docker-compose.test.yml
+++ b/3.1/focal/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/3.1/focal/hooks/post_push
+++ b/3.1/focal/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag 3.1.3-focal

--- a/3.2/focal/Dockerfile
+++ b/3.2/focal/Dockerfile
@@ -1,0 +1,23 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:focal
+
+ARG R_VERSION=3.2.5
+ARG OS_IDENTIFIER=ubuntu-2004
+
+# Install R
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/r-${R_VERSION}_1_amd64.deb && \
+    apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -f -y ./r-${R_VERSION}_1_amd64.deb && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm r-${R_VERSION}_1_amd64.deb && \
+    rm -rf /var/lib/apt/lists/*
+
+CMD ["R"]

--- a/3.2/focal/docker-compose.test.yml
+++ b/3.2/focal/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/3.2/focal/hooks/post_push
+++ b/3.2/focal/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag 3.2.5-focal

--- a/3.3/focal/Dockerfile
+++ b/3.3/focal/Dockerfile
@@ -1,0 +1,23 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:focal
+
+ARG R_VERSION=3.3.3
+ARG OS_IDENTIFIER=ubuntu-2004
+
+# Install R
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/r-${R_VERSION}_1_amd64.deb && \
+    apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -f -y ./r-${R_VERSION}_1_amd64.deb && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm r-${R_VERSION}_1_amd64.deb && \
+    rm -rf /var/lib/apt/lists/*
+
+CMD ["R"]

--- a/3.3/focal/docker-compose.test.yml
+++ b/3.3/focal/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/3.3/focal/hooks/post_push
+++ b/3.3/focal/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag 3.3.3-focal

--- a/3.4/focal/Dockerfile
+++ b/3.4/focal/Dockerfile
@@ -1,0 +1,23 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:focal
+
+ARG R_VERSION=3.4.4
+ARG OS_IDENTIFIER=ubuntu-2004
+
+# Install R
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/r-${R_VERSION}_1_amd64.deb && \
+    apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -f -y ./r-${R_VERSION}_1_amd64.deb && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm r-${R_VERSION}_1_amd64.deb && \
+    rm -rf /var/lib/apt/lists/*
+
+CMD ["R"]

--- a/3.4/focal/docker-compose.test.yml
+++ b/3.4/focal/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/3.4/focal/hooks/post_push
+++ b/3.4/focal/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag 3.4.4-focal

--- a/3.5/focal/Dockerfile
+++ b/3.5/focal/Dockerfile
@@ -1,0 +1,23 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:focal
+
+ARG R_VERSION=3.5.3
+ARG OS_IDENTIFIER=ubuntu-2004
+
+# Install R
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/r-${R_VERSION}_1_amd64.deb && \
+    apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -f -y ./r-${R_VERSION}_1_amd64.deb && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm r-${R_VERSION}_1_amd64.deb && \
+    rm -rf /var/lib/apt/lists/*
+
+CMD ["R"]

--- a/3.5/focal/docker-compose.test.yml
+++ b/3.5/focal/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/3.5/focal/hooks/post_push
+++ b/3.5/focal/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag 3.5.3-focal

--- a/3.6/focal/Dockerfile
+++ b/3.6/focal/Dockerfile
@@ -1,0 +1,23 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:focal
+
+ARG R_VERSION=3.6.3
+ARG OS_IDENTIFIER=ubuntu-2004
+
+# Install R
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/r-${R_VERSION}_1_amd64.deb && \
+    apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -f -y ./r-${R_VERSION}_1_amd64.deb && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm r-${R_VERSION}_1_amd64.deb && \
+    rm -rf /var/lib/apt/lists/*
+
+CMD ["R"]

--- a/3.6/focal/docker-compose.test.yml
+++ b/3.6/focal/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/3.6/focal/hooks/post_push
+++ b/3.6/focal/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag 3.6.3-focal

--- a/4.0/focal/Dockerfile
+++ b/4.0/focal/Dockerfile
@@ -1,0 +1,23 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:focal
+
+ARG R_VERSION=4.0.0
+ARG OS_IDENTIFIER=ubuntu-2004
+
+# Install R
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/r-${R_VERSION}_1_amd64.deb && \
+    apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -f -y ./r-${R_VERSION}_1_amd64.deb && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm r-${R_VERSION}_1_amd64.deb && \
+    rm -rf /var/lib/apt/lists/*
+
+CMD ["R"]

--- a/4.0/focal/docker-compose.test.yml
+++ b/4.0/focal/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/4.0/focal/hooks/post_push
+++ b/4.0/focal/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag 4.0.0-focal

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BASE_IMAGE ?= rstudio/r-base
 VERSIONS = 3.1 3.2 3.3 3.4 3.5 3.6 4.0
-VARIANTS = xenial bionic centos6 centos7 centos8 opensuse42 opensuse15
+VARIANTS = xenial bionic focal centos6 centos7 centos8 opensuse42 opensuse15
 
 all: build-all test-all
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The following distributions are supported:
 | ------------- |-----------|
 | xenial        | Ubuntu 16.04 |
 | bionic        | Ubuntu 18.04 |
+| focal         | Ubuntu 20.04 |
 | centos6       | CentOS 6 |
 | centos7       | CentOS 7 |
 | centos8       | CentOS 8 |

--- a/base/bionic/Dockerfile
+++ b/base/bionic/Dockerfile
@@ -7,18 +7,12 @@ RUN apt-get update -qq && \
     apt-transport-https \
     curl \
     fontconfig \
-    libbz2-dev \
     libcurl4-openssl-dev \
-    libicu-dev \
-    liblzma-dev \
-    libpcre2-dev \
-    libpcre3-dev \
     locales \
     perl \
     sudo \
     tzdata \
-    wget \
-    zlib1g-dev && \
+    wget && \
     rm -rf /var/lib/apt/lists/*
 
 # Install TinyTeX

--- a/base/focal/Dockerfile
+++ b/base/focal/Dockerfile
@@ -1,0 +1,38 @@
+FROM ubuntu:focal
+
+LABEL maintainer="RStudio Docker <docker@rstudio.com>"
+
+RUN apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    apt-transport-https \
+    curl \
+    fontconfig \
+    libcurl4-openssl-dev \
+    locales \
+    perl \
+    sudo \
+    tzdata \
+    wget && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install TinyTeX
+RUN wget -qO- "https://yihui.name/gh/tinytex/tools/install-unx.sh" | sh -s - --admin --no-path && \
+    mv ~/.TinyTeX /opt/TinyTeX && \
+    /opt/TinyTeX/bin/*/tlmgr path add
+
+# Install pandoc
+RUN mkdir -p /opt/pandoc && \
+    wget -O /opt/pandoc/pandoc.gz https://files.r-hub.io/pandoc/linux-64/pandoc.gz && \
+    gzip -d /opt/pandoc/pandoc.gz && \
+    chmod +x /opt/pandoc/pandoc && \
+    ln -s /opt/pandoc/pandoc /usr/bin/pandoc && \
+    wget -O /opt/pandoc/pandoc-citeproc.gz https://files.r-hub.io/pandoc/linux-64/pandoc-citeproc.gz && \
+    gzip -d /opt/pandoc/pandoc-citeproc.gz && \
+    chmod +x /opt/pandoc/pandoc-citeproc && \
+    ln -s /opt/pandoc/pandoc-citeproc /usr/bin/pandoc-citeproc
+
+# Set default locale
+ENV LANG C.UTF-8
+
+# Set default timezone
+ENV TZ UTC

--- a/base/xenial/Dockerfile
+++ b/base/xenial/Dockerfile
@@ -6,18 +6,12 @@ RUN apt-get update -qq && \
     apt-transport-https \
     curl \
     fontconfig \
-    libbz2-dev \
     libcurl4-openssl-dev \
-    libicu-dev \
-    liblzma-dev \
-    libpcre2-dev \
-    libpcre3-dev \
     locales \
     perl \
     sudo \
     tzdata \
-    wget \
-    zlib1g-dev && \
+    wget && \
     rm -rf /var/lib/apt/lists/*
 
 # Install TinyTeX

--- a/update.sh
+++ b/update.sh
@@ -14,6 +14,7 @@ declare -A r_versions=(
 declare -A os_identifiers=(
     [xenial]='ubuntu-1604'
     [bionic]='ubuntu-1804'
+    [focal]='ubuntu-2004'
     [centos6]='centos-6'
     [centos7]='centos-7'
     [centos8]='centos-8'
@@ -39,7 +40,7 @@ for version in "${!r_versions[@]}"; do
         mkdir -p $dir
 
         case "$variant" in
-            xenial|bionic) template='ubuntu'
+            xenial|bionic|focal) template='ubuntu'
             ;;
             centos6|centos7|centos8) template='centos'
             ;;


### PR DESCRIPTION
Add images for Ubuntu 20.04 Focal.

Also remove some redundant system packages from Ubuntu 16/18 that are now included via R binaries: libpcre, libicu, libbz2, liblzma, zlib1g: https://github.com/rstudio/r-builds/pull/63/files#diff-f662e6debfa6739a09cb46d54c95735aL23

From a container diff, there should be no difference except that the new image only includes either one of libpcre2 (PCRE 2 for R 4.0+) or libpcre3 (PCRE 1 for R 3.6 and below), not both:
```sh
# Old image: rstudio/r-base:3.6-bionic
# New image: r-base-test:3.6-bionic
$ container-diff diff daemon://rstudio/r-base:3.6-bionic daemon://r-base-test:3.6-bionic --type=apt

-----Apt-----

Packages found only in rstudio/r-base:3.6-bionic:
NAME                    VERSION        SIZE
-libpcre2-16-0          10.31-2        491K
-libpcre2-32-0          10.31-2        471K
-libpcre2-8-0           10.31-2        536K
-libpcre2-dev           10.31-2        2.2M
-libpcre2-posix0        10.31-2        27K

Packages found only in r-base-test:3.6-bionic: None
```