### PR TITLE
Add R-devel images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,9 +5,18 @@ build-images: &build-images
     publish:
       type: boolean
       default: false
+    versions:
+      type: string
+      default: ""
   machine: true
   steps:
     - checkout
+    - when:
+        condition: << parameters.versions >>
+        steps:
+          - run:
+              name: Setup custom environment variables
+              command: echo 'export VERSIONS=<< parameters.versions >>' >> $BASH_ENV
     - run:
         name: Build images
         command: make build-all
@@ -35,6 +44,10 @@ branch-default: &branch-default
   filters:
     branches:
       ignore: master
+
+r-devel: &r-devel
+  publish: true
+  versions: devel
 
 jobs:
   xenial:
@@ -109,3 +122,28 @@ workflows:
           <<: *branch-master
       - opensuse15:
           <<: *branch-master
+  build-r-devel-daily:
+    triggers:
+      - schedule:
+          cron: "0 6 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - xenial:
+          <<: *r-devel
+      - bionic:
+          <<: *r-devel
+      - focal:
+          <<: *r-devel
+      - centos6:
+          <<: *r-devel
+      - centos7:
+          <<: *r-devel
+      - centos8:
+          <<: *r-devel
+      - opensuse42:
+          <<: *r-devel
+      - opensuse15:
+          <<: *r-devel

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,10 +10,10 @@ build-images: &build-images
     - checkout
     - run:
         name: Build images
-        command: make build-all VARIANTS=$VARIANT
+        command: make build-all
     - run:
         name: Test images
-        command: make test-all VARIANTS=$VARIANT
+        command: make test-all
     - when:
         condition: << parameters.publish >>
         steps:
@@ -22,7 +22,7 @@ build-images: &build-images
               command: echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
           - run:
               name: Publish images
-              command: make push-all VARIANTS=$VARIANT
+              command: make push-all
 
 branch-master: &branch-master
   publish: true
@@ -40,35 +40,35 @@ jobs:
   xenial:
     <<: *build-images
     environment:
-      VARIANT: xenial
+      VARIANTS: xenial
   bionic:
     <<: *build-images
     environment:
-      VARIANT: bionic
+      VARIANTS: bionic
   focal:
     <<: *build-images
     environment:
-      VARIANT: focal
+      VARIANTS: focal
   centos6:
     <<: *build-images
     environment:
-      VARIANT: centos6
+      VARIANTS: centos6
   centos7:
     <<: *build-images
     environment:
-      VARIANT: centos7
+      VARIANTS: centos7
   centos8:
     <<: *build-images
     environment:
-      VARIANT: centos8
+      VARIANTS: centos8
   opensuse42:
     <<: *build-images
     environment:
-      VARIANT: opensuse42
+      VARIANTS: opensuse42
   opensuse15:
     <<: *build-images
     environment:
-      VARIANT: opensuse15
+      VARIANTS: opensuse15
   
 
 workflows:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BASE_IMAGE ?= rstudio/r-base
-VERSIONS = 3.1 3.2 3.3 3.4 3.5 3.6 4.0
-VARIANTS = xenial bionic focal centos6 centos7 centos8 opensuse42 opensuse15
+VERSIONS ?= 3.1 3.2 3.3 3.4 3.5 3.6 4.0 devel
+VARIANTS ?= xenial bionic focal centos6 centos7 centos8 opensuse42 opensuse15
 
 all: build-all test-all
 

--- a/devel/bionic/Dockerfile
+++ b/devel/bionic/Dockerfile
@@ -1,0 +1,23 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:bionic
+
+ARG R_VERSION=devel
+ARG OS_IDENTIFIER=ubuntu-1804
+
+# Install R
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/r-${R_VERSION}_1_amd64.deb && \
+    apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -f -y ./r-${R_VERSION}_1_amd64.deb && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm r-${R_VERSION}_1_amd64.deb && \
+    rm -rf /var/lib/apt/lists/*
+
+CMD ["R"]

--- a/devel/bionic/docker-compose.test.yml
+++ b/devel/bionic/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/devel/bionic/hooks/post_push
+++ b/devel/bionic/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag devel-bionic

--- a/devel/centos6/Dockerfile
+++ b/devel/centos6/Dockerfile
@@ -1,0 +1,24 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:centos6
+
+ARG R_VERSION=devel
+ARG OS_IDENTIFIER=centos-6
+
+# Install R
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    yum -y install epel-release && \
+    yum -y install ./R-${R_VERSION}-1-1.x86_64.rpm && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    yum -y remove epel-release && \
+    yum clean all
+
+CMD ["R"]

--- a/devel/centos6/docker-compose.test.yml
+++ b/devel/centos6/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/devel/centos6/hooks/post_push
+++ b/devel/centos6/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag devel-centos6

--- a/devel/centos7/Dockerfile
+++ b/devel/centos7/Dockerfile
@@ -1,0 +1,24 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:centos7
+
+ARG R_VERSION=devel
+ARG OS_IDENTIFIER=centos-7
+
+# Install R
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    yum -y install epel-release && \
+    yum -y install ./R-${R_VERSION}-1-1.x86_64.rpm && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    yum -y remove epel-release && \
+    yum clean all
+
+CMD ["R"]

--- a/devel/centos7/docker-compose.test.yml
+++ b/devel/centos7/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/devel/centos7/hooks/post_push
+++ b/devel/centos7/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag devel-centos7

--- a/devel/centos8/Dockerfile
+++ b/devel/centos8/Dockerfile
@@ -1,0 +1,24 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:centos8
+
+ARG R_VERSION=devel
+ARG OS_IDENTIFIER=centos-8
+
+# Install R
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    yum -y install epel-release && \
+    yum -y install ./R-${R_VERSION}-1-1.x86_64.rpm && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    yum -y remove epel-release && \
+    yum clean all
+
+CMD ["R"]

--- a/devel/centos8/docker-compose.test.yml
+++ b/devel/centos8/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/devel/centos8/hooks/post_push
+++ b/devel/centos8/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag devel-centos8

--- a/devel/focal/Dockerfile
+++ b/devel/focal/Dockerfile
@@ -1,0 +1,23 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:focal
+
+ARG R_VERSION=devel
+ARG OS_IDENTIFIER=ubuntu-2004
+
+# Install R
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/r-${R_VERSION}_1_amd64.deb && \
+    apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -f -y ./r-${R_VERSION}_1_amd64.deb && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm r-${R_VERSION}_1_amd64.deb && \
+    rm -rf /var/lib/apt/lists/*
+
+CMD ["R"]

--- a/devel/focal/docker-compose.test.yml
+++ b/devel/focal/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/devel/focal/hooks/post_push
+++ b/devel/focal/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag devel-focal

--- a/devel/opensuse15/Dockerfile
+++ b/devel/opensuse15/Dockerfile
@@ -1,0 +1,22 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:opensuse15
+
+ARG R_VERSION=devel
+ARG OS_IDENTIFIER=opensuse-15
+
+# Install R
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper --non-interactive --no-gpg-checks install ./R-${R_VERSION}-1-1.x86_64.rpm && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper clean --all
+
+CMD ["R"]

--- a/devel/opensuse15/docker-compose.test.yml
+++ b/devel/opensuse15/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/devel/opensuse15/hooks/post_push
+++ b/devel/opensuse15/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag devel-opensuse15

--- a/devel/opensuse42/Dockerfile
+++ b/devel/opensuse42/Dockerfile
@@ -1,0 +1,22 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:opensuse42
+
+ARG R_VERSION=devel
+ARG OS_IDENTIFIER=opensuse-42
+
+# Install R
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper --non-interactive --no-gpg-checks install ./R-${R_VERSION}-1-1.x86_64.rpm && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper clean --all
+
+CMD ["R"]

--- a/devel/opensuse42/docker-compose.test.yml
+++ b/devel/opensuse42/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/devel/opensuse42/hooks/post_push
+++ b/devel/opensuse42/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag devel-opensuse42

--- a/devel/xenial/Dockerfile
+++ b/devel/xenial/Dockerfile
@@ -1,0 +1,23 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:xenial
+
+ARG R_VERSION=devel
+ARG OS_IDENTIFIER=ubuntu-1604
+
+# Install R
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/r-${R_VERSION}_1_amd64.deb && \
+    apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -f -y ./r-${R_VERSION}_1_amd64.deb && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm r-${R_VERSION}_1_amd64.deb && \
+    rm -rf /var/lib/apt/lists/*
+
+CMD ["R"]

--- a/devel/xenial/docker-compose.test.yml
+++ b/devel/xenial/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/devel/xenial/hooks/post_push
+++ b/devel/xenial/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag devel-xenial

--- a/update.sh
+++ b/update.sh
@@ -9,6 +9,7 @@ declare -A r_versions=(
     [3.5]='3.5.3'
     [3.6]='3.6.3'
     [4.0]='4.0.2'
+    [devel]='devel'
 )
 
 declare -A os_identifiers=(


### PR DESCRIPTION
For https://github.com/rstudio/r-docker/issues/39:

- Adds R-devel images. R-devel binaries are now being built daily at around 4 AM UTC: https://github.com/rstudio/r-builds/pull/71
- Schedules R-devel images to be built daily at 6 AM UTC. The CircleCI config changes for this are kind of ugly, but I believe it works. In particular, CircleCI limits where you can set environment variables vs. parameters, so parameterization is done through a mix of environment variables and build parameters.