### PR TITLE
Add images for openSUSE 15.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,11 @@ jobs:
     <<: *build-images
     environment:
       VARIANTS: opensuse15
-  
+  opensuse152:
+    <<: *build-images
+    environment:
+      VARIANTS: opensuse152
+
 
 workflows:
   version: 2
@@ -104,6 +108,8 @@ workflows:
           <<: *branch-default
       - opensuse15:
           <<: *branch-default
+      - opensuse152:
+          <<: *branch-default
   build-master:
     jobs:
       - xenial:
@@ -121,6 +127,8 @@ workflows:
       - opensuse42:
           <<: *branch-master
       - opensuse15:
+          <<: *branch-master
+      - opensuse152:
           <<: *branch-master
   build-r-devel-daily:
     triggers:
@@ -146,4 +154,6 @@ workflows:
       - opensuse42:
           <<: *r-devel
       - opensuse15:
+          <<: *r-devel
+      - opensuse152:
           <<: *r-devel

--- a/3.1/opensuse152/Dockerfile
+++ b/3.1/opensuse152/Dockerfile
@@ -1,0 +1,22 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:opensuse152
+
+ARG R_VERSION=3.1.3
+ARG OS_IDENTIFIER=opensuse-152
+
+# Install R
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper --non-interactive --no-gpg-checks install ./R-${R_VERSION}-1-1.x86_64.rpm && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper clean --all
+
+CMD ["R"]

--- a/3.1/opensuse152/docker-compose.test.yml
+++ b/3.1/opensuse152/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/3.1/opensuse152/hooks/post_push
+++ b/3.1/opensuse152/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag 3.1.3-opensuse152

--- a/3.2/opensuse152/Dockerfile
+++ b/3.2/opensuse152/Dockerfile
@@ -1,0 +1,22 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:opensuse152
+
+ARG R_VERSION=3.2.5
+ARG OS_IDENTIFIER=opensuse-152
+
+# Install R
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper --non-interactive --no-gpg-checks install ./R-${R_VERSION}-1-1.x86_64.rpm && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper clean --all
+
+CMD ["R"]

--- a/3.2/opensuse152/docker-compose.test.yml
+++ b/3.2/opensuse152/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/3.2/opensuse152/hooks/post_push
+++ b/3.2/opensuse152/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag 3.2.5-opensuse152

--- a/3.3/opensuse152/Dockerfile
+++ b/3.3/opensuse152/Dockerfile
@@ -1,0 +1,22 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:opensuse152
+
+ARG R_VERSION=3.3.3
+ARG OS_IDENTIFIER=opensuse-152
+
+# Install R
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper --non-interactive --no-gpg-checks install ./R-${R_VERSION}-1-1.x86_64.rpm && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper clean --all
+
+CMD ["R"]

--- a/3.3/opensuse152/docker-compose.test.yml
+++ b/3.3/opensuse152/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/3.3/opensuse152/hooks/post_push
+++ b/3.3/opensuse152/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag 3.3.3-opensuse152

--- a/3.4/opensuse152/Dockerfile
+++ b/3.4/opensuse152/Dockerfile
@@ -1,0 +1,22 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:opensuse152
+
+ARG R_VERSION=3.4.4
+ARG OS_IDENTIFIER=opensuse-152
+
+# Install R
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper --non-interactive --no-gpg-checks install ./R-${R_VERSION}-1-1.x86_64.rpm && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper clean --all
+
+CMD ["R"]

--- a/3.4/opensuse152/docker-compose.test.yml
+++ b/3.4/opensuse152/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/3.4/opensuse152/hooks/post_push
+++ b/3.4/opensuse152/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag 3.4.4-opensuse152

--- a/3.5/opensuse152/Dockerfile
+++ b/3.5/opensuse152/Dockerfile
@@ -1,0 +1,22 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:opensuse152
+
+ARG R_VERSION=3.5.3
+ARG OS_IDENTIFIER=opensuse-152
+
+# Install R
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper --non-interactive --no-gpg-checks install ./R-${R_VERSION}-1-1.x86_64.rpm && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper clean --all
+
+CMD ["R"]

--- a/3.5/opensuse152/docker-compose.test.yml
+++ b/3.5/opensuse152/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/3.5/opensuse152/hooks/post_push
+++ b/3.5/opensuse152/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag 3.5.3-opensuse152

--- a/3.6/opensuse152/Dockerfile
+++ b/3.6/opensuse152/Dockerfile
@@ -1,0 +1,22 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:opensuse152
+
+ARG R_VERSION=3.6.3
+ARG OS_IDENTIFIER=opensuse-152
+
+# Install R
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper --non-interactive --no-gpg-checks install ./R-${R_VERSION}-1-1.x86_64.rpm && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper clean --all
+
+CMD ["R"]

--- a/3.6/opensuse152/docker-compose.test.yml
+++ b/3.6/opensuse152/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/3.6/opensuse152/hooks/post_push
+++ b/3.6/opensuse152/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag 3.6.3-opensuse152

--- a/4.0/opensuse152/Dockerfile
+++ b/4.0/opensuse152/Dockerfile
@@ -1,0 +1,22 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:opensuse152
+
+ARG R_VERSION=4.0.2
+ARG OS_IDENTIFIER=opensuse-152
+
+# Install R
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper --non-interactive --no-gpg-checks install ./R-${R_VERSION}-1-1.x86_64.rpm && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper clean --all
+
+CMD ["R"]

--- a/4.0/opensuse152/docker-compose.test.yml
+++ b/4.0/opensuse152/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/4.0/opensuse152/hooks/post_push
+++ b/4.0/opensuse152/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag 4.0.2-opensuse152

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BASE_IMAGE ?= rstudio/r-base
 VERSIONS ?= 3.1 3.2 3.3 3.4 3.5 3.6 4.0 devel
-VARIANTS ?= xenial bionic focal centos6 centos7 centos8 opensuse42 opensuse15
+VARIANTS ?= xenial bionic focal centos6 centos7 centos8 opensuse42 opensuse15 opensuse152
 
 all: build-all test-all
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The following distributions are supported:
 | centos8       | CentOS 8 |
 | opensuse42    | openSUSE 42.3 |
 | opensuse15    | openSUSE 15.0 |
+| opensuse152   | openSUSE 15.2 |
 
 All minor versions of R since 3.1 are supported, on the latest patch release.
 

--- a/base/opensuse152/Dockerfile
+++ b/base/opensuse152/Dockerfile
@@ -1,0 +1,34 @@
+FROM opensuse/leap:15.2
+LABEL maintainer="RStudio Docker <docker@rstudio.com>"
+
+RUN zypper --non-interactive update
+RUN zypper --non-interactive --gpg-auto-import-keys install \
+    fontconfig \
+    gzip \
+    sudo \
+    tar \
+    vim \
+    wget \
+    && zypper clean --all
+
+# Install TinyTeX
+RUN wget -qO- "https://yihui.name/gh/tinytex/tools/install-unx.sh" | sh -s - --admin --no-path && \
+    mv ~/.TinyTeX /opt/TinyTeX && \
+    /opt/TinyTeX/bin/*/tlmgr path add
+
+# Install pandoc
+RUN mkdir -p /opt/pandoc && \
+    wget -O /opt/pandoc/pandoc.gz https://files.r-hub.io/pandoc/linux-64/pandoc.gz && \
+    gzip -d /opt/pandoc/pandoc.gz && \
+    chmod +x /opt/pandoc/pandoc && \
+    ln -s /opt/pandoc/pandoc /usr/bin/pandoc && \
+    wget -O /opt/pandoc/pandoc-citeproc.gz https://files.r-hub.io/pandoc/linux-64/pandoc-citeproc.gz && \
+    gzip -d /opt/pandoc/pandoc-citeproc.gz && \
+    chmod +x /opt/pandoc/pandoc-citeproc && \
+    ln -s /opt/pandoc/pandoc-citeproc /usr/bin/pandoc-citeproc
+
+# Set default locale
+ENV LANG C.UTF-8
+
+# Set default timezone
+ENV TZ UTC

--- a/devel/opensuse152/Dockerfile
+++ b/devel/opensuse152/Dockerfile
@@ -1,0 +1,22 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:opensuse152
+
+ARG R_VERSION=devel
+ARG OS_IDENTIFIER=opensuse-152
+
+# Install R
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper --non-interactive --no-gpg-checks install ./R-${R_VERSION}-1-1.x86_64.rpm && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper clean --all
+
+CMD ["R"]

--- a/devel/opensuse152/docker-compose.test.yml
+++ b/devel/opensuse152/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/devel/opensuse152/hooks/post_push
+++ b/devel/opensuse152/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag devel-opensuse152

--- a/update.sh
+++ b/update.sh
@@ -21,6 +21,7 @@ declare -A os_identifiers=(
     [centos8]='centos-8'
     [opensuse42]='opensuse-42'
     [opensuse15]='opensuse-15'
+    [opensuse152]='opensuse-152'
 )
 
 generated_warning() {
@@ -45,7 +46,7 @@ for version in "${!r_versions[@]}"; do
             ;;
             centos6|centos7|centos8) template='centos'
             ;;
-            opensuse42|opensuse15) template='opensuse'
+            opensuse42|opensuse15|opensuse152) template='opensuse'
             ;;
         esac
 


### PR DESCRIPTION
Now that openSUSE 15.2 R binaries are available (https://github.com/rstudio/r-builds/pull/73), we can add images for openSUSE 15.2.