### PR TITLE
Build and maintain R patch versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,9 @@ build-images: &build-images
     versions:
       type: string
       default: ""
+    include_patch_versions:
+      type: boolean
+      default: false
   machine: true
   steps:
     - checkout
@@ -15,8 +18,14 @@ build-images: &build-images
         condition: << parameters.versions >>
         steps:
           - run:
-              name: Setup custom environment variables
+              name: Setup custom R versions to build
               command: echo 'export VERSIONS=<< parameters.versions >>' >> $BASH_ENV
+    - when:
+        condition: << parameters.include_patch_versions >>
+        steps:
+          - run:
+              name: Setup to build R patch versions
+              command: echo 'export INCLUDE_PATCH_VERSIONS=yes' >> $BASH_ENV
     - run:
         name: Build images
         command: make build-all
@@ -48,6 +57,10 @@ branch-default: &branch-default
 r-devel: &r-devel
   publish: true
   versions: devel
+
+r-patch-versions: &r-patch-versions
+  publish: true
+  include_patch_versions: true
 
 jobs:
   xenial:
@@ -147,3 +160,28 @@ workflows:
           <<: *r-devel
       - opensuse152:
           <<: *r-devel
+  build-r-patch-versions-monthly:
+    triggers:
+      - schedule:
+          cron: "0 0 3 * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - xenial:
+          <<: *r-patch-versions
+      - bionic:
+          <<: *r-patch-versions
+      - focal:
+          <<: *r-patch-versions
+      - centos7:
+          <<: *r-patch-versions
+      - centos8:
+          <<: *r-patch-versions
+      - opensuse42:
+          <<: *r-patch-versions
+      - opensuse15:
+          <<: *r-patch-versions
+      - opensuse152:
+          <<: *r-patch-versions

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,14 @@ BASE_IMAGE ?= rstudio/r-base
 VERSIONS ?= 3.1 3.2 3.3 3.4 3.5 3.6 4.0 devel
 VARIANTS ?= xenial bionic focal centos7 centos8 opensuse42 opensuse15 opensuse152
 
+# PATCH_VERSIONS defines all actively maintained R patch versions.
+PATCH_VERSIONS ?= 3.1.3 3.2.5 3.3.3 3.4.4 3.5.3 \
+	3.6.0 3.6.1 3.6.2 3.6.3 \
+	4.0.0 4.0.1 4.0.2 4.0.3
+# INCLUDE_PATCH_VERSIONS, if set to `yes`, includes all patch versions in the
+# "all" targets.
+INCLUDE_PATCH_VERSIONS ?= no
+
 all: build-all test-all
 
 update-all-docker:
@@ -49,6 +57,50 @@ endef
 $(foreach variant,$(VARIANTS), \
   $(foreach version,$(VERSIONS), \
     $(eval $(GEN_R_IMAGE_TARGETS)) \
+  ) \
+)
+
+define minor_version
+$(shell echo $(version) | cut -d. -f-2)
+endef
+
+define GEN_R_PATCH_IMAGE_TARGETS
+build-$(version)-$(variant): build-base-$(variant)
+	docker build -t $(BASE_IMAGE):$(version)-$(variant) \
+		--build-arg BASE_IMAGE=$(BASE_IMAGE) \
+		--build-arg R_VERSION=$(version) \
+		$(minor_version)/$(variant)/.
+
+rebuild-$(version)-$(variant): build-base-$(variant)
+	docker build --no-cache -t $(BASE_IMAGE):$(version)-$(variant) \
+		--build-arg BASE_IMAGE=$(BASE_IMAGE) \
+		--build-arg R_VERSION=$(version) \
+		$(minor_version)/$(variant)/.
+
+test-$(version)-$(variant):
+	docker run -it --rm -v $(PWD)/test:/test $(BASE_IMAGE):$(version)-$(variant) bash -l /test/test.sh
+
+bash-$(version)-$(variant):
+	docker run -it --rm -v $(PWD)/test:/test $(BASE_IMAGE):$(version)-$(variant) bash
+
+pull-$(version)-$(variant):
+	docker pull $(BASE_IMAGE):$(version)-$(variant)
+
+push-$(version)-$(variant):
+	docker push $(BASE_IMAGE):$(version)-$(variant)
+
+ifeq (yes,$(INCLUDE_PATCH_VERSIONS))
+BUILD_R_IMAGES += build-$(version)-$(variant)
+REBUILD_R_IMAGES += rebuild-$(version)-$(variant)
+TEST_R_IMAGES += test-$(version)-$(variant)
+PULL_R_IMAGES += pull-$(version)-$(variant)
+PUSH_R_IMAGES += push-$(version)-$(variant)
+endif
+endef
+
+$(foreach variant,$(VARIANTS), \
+  $(foreach version,$(PATCH_VERSIONS), \
+    $(eval $(GEN_R_PATCH_IMAGE_TARGETS)) \
   ) \
 )
 

--- a/README.md
+++ b/README.md
@@ -101,21 +101,29 @@ In general, the structure consists of the following:
 
 
 ### Building Images
+
 ```bash
 # Build and test all images
 make
 
 # Build and test images for a specific R version
-make VERSIONS=3.4
+make VERSIONS=4.0
 
 # Build and test images for a specific distro
-make VARIANTS=xenial
+make VARIANTS=focal
 
 # Build a specific image
-make build-3.4-xenial
+make build-4.0-focal
+# Build a specific patch version
+make build-4.0.3-focal
 
 # Test a specific image
-make test-3.4-xenial
+make test-4.0-focal
+# Test a specific patch version
+make test-4.0.3-focal
+
+# Build and test all images, including historic patch versions
+make INCLUDE_PATCH_VERSIONS=yes
 ```
 
 ### Updating Images


### PR DESCRIPTION
- Adds support for building R patch versions
- Adds a CI job that rebuilds all patch versions once a month, so that they're actively maintained and updated with security patches (e.g., Baron Samedit sudo vulnerability). I think this job can also be manually triggered via the CircleCI console if needed.

Currently supported patch versions are just the tags available on Docker Hub, which are R 3.6.0, 3.6.1, 3.6.2, 3.6.3, 4.0.0, 4.0.1, 4.0.2, 4.0.3, and all the latest patch versions from R 3.5 and below. It's a large matrix and the job currently takes 2+ hours, but at least there are only a few R releases a year, and the job only runs once a month. Here's a one-off build I did on another branch: https://app.circleci.com/pipelines/github/rstudio/r-docker/355/workflows/761bfc85-5d6f-40e8-9c77-22ef9a90c0c1

To build patch versions manually:
```sh
# Build, test, and push R 3.6.0 xenial
make build-3.6.0-xenial
make test-3.6.0-xenial
make push-3.6.0-xenial

# Build, test, and push all R patch versions
INCLUDE_PATCH_VERSIONS=yes make build-all
INCLUDE_PATCH_VERSIONS=yes make test-all
INCLUDE_PATCH_VERSIONS=yes make push-all

# The "all" targets still build just the minor versions by default
make build-all
```
