### PR TITLE
Fix tests that depend on removed CRAN package

### DIFF
--- a/test/test.R
+++ b/test/test.R
@@ -1,13 +1,9 @@
 # HTTP mirror to support R 3.1
 options(repos = c("https://cloud.r-project.org", "http://cloud.r-project.org"))
 
-# Install a package without compilation
+# Check that packages can be installed
 install.packages("R6")
 library(R6)
-
-# Install a package with compilation
-install.packages("BASIX")
-library(BASIX)
 
 # Check that the time zone database is present
 # https://stat.ethz.ch/R-manual/R-devel/library/base/html/timezones.html


### PR DESCRIPTION
Fix a failing test that blocks the daily devel builds.

There was a test that relied on a now-removed CRAN package, BASIX, for installing a package with C code. There's already another test that does this using a local test package, so we don't need the BASIX test anymore.