### PR TITLE
Add images for Rocky Linux 9, openSUSE 15.4

### DIFF
--- a/3.1/opensuse154/Dockerfile
+++ b/3.1/opensuse154/Dockerfile
@@ -1,0 +1,22 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:opensuse154
+
+ARG R_VERSION=3.1.3
+ARG OS_IDENTIFIER=opensuse-154
+
+# Install R
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper --non-interactive --no-gpg-checks install ./R-${R_VERSION}-1-1.x86_64.rpm && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper clean --all
+
+CMD ["R"]

--- a/3.1/opensuse154/docker-compose.test.yml
+++ b/3.1/opensuse154/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/3.1/opensuse154/hooks/post_push
+++ b/3.1/opensuse154/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag 3.1.3-opensuse154

--- a/3.1/rockylinux9/Dockerfile
+++ b/3.1/rockylinux9/Dockerfile
@@ -1,0 +1,27 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:rockylinux9
+
+ARG R_VERSION=3.1.3
+ARG OS_IDENTIFIER=rhel-9
+
+# Install R
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    dnf -y install dnf-plugins-core && \
+    dnf config-manager --set-enabled crb && \
+    dnf -y install epel-release && \
+    dnf -y install ./R-${R_VERSION}-1-1.x86_64.rpm && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    dnf -y remove epel-release && \
+    dnf config-manager --set-disabled crb && \
+    dnf clean all
+
+CMD ["R"]

--- a/3.1/rockylinux9/docker-compose.test.yml
+++ b/3.1/rockylinux9/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/3.1/rockylinux9/hooks/post_push
+++ b/3.1/rockylinux9/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag 3.1.3-rockylinux9

--- a/3.2/opensuse154/Dockerfile
+++ b/3.2/opensuse154/Dockerfile
@@ -1,0 +1,22 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:opensuse154
+
+ARG R_VERSION=3.2.5
+ARG OS_IDENTIFIER=opensuse-154
+
+# Install R
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper --non-interactive --no-gpg-checks install ./R-${R_VERSION}-1-1.x86_64.rpm && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper clean --all
+
+CMD ["R"]

--- a/3.2/opensuse154/docker-compose.test.yml
+++ b/3.2/opensuse154/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/3.2/opensuse154/hooks/post_push
+++ b/3.2/opensuse154/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag 3.2.5-opensuse154

--- a/3.2/rockylinux9/Dockerfile
+++ b/3.2/rockylinux9/Dockerfile
@@ -1,0 +1,27 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:rockylinux9
+
+ARG R_VERSION=3.2.5
+ARG OS_IDENTIFIER=rhel-9
+
+# Install R
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    dnf -y install dnf-plugins-core && \
+    dnf config-manager --set-enabled crb && \
+    dnf -y install epel-release && \
+    dnf -y install ./R-${R_VERSION}-1-1.x86_64.rpm && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    dnf -y remove epel-release && \
+    dnf config-manager --set-disabled crb && \
+    dnf clean all
+
+CMD ["R"]

--- a/3.2/rockylinux9/docker-compose.test.yml
+++ b/3.2/rockylinux9/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/3.2/rockylinux9/hooks/post_push
+++ b/3.2/rockylinux9/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag 3.2.5-rockylinux9

--- a/3.3/opensuse154/Dockerfile
+++ b/3.3/opensuse154/Dockerfile
@@ -1,0 +1,22 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:opensuse154
+
+ARG R_VERSION=3.3.3
+ARG OS_IDENTIFIER=opensuse-154
+
+# Install R
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper --non-interactive --no-gpg-checks install ./R-${R_VERSION}-1-1.x86_64.rpm && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper clean --all
+
+CMD ["R"]

--- a/3.3/opensuse154/docker-compose.test.yml
+++ b/3.3/opensuse154/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/3.3/opensuse154/hooks/post_push
+++ b/3.3/opensuse154/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag 3.3.3-opensuse154

--- a/3.3/rockylinux9/Dockerfile
+++ b/3.3/rockylinux9/Dockerfile
@@ -1,0 +1,27 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:rockylinux9
+
+ARG R_VERSION=3.3.3
+ARG OS_IDENTIFIER=rhel-9
+
+# Install R
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    dnf -y install dnf-plugins-core && \
+    dnf config-manager --set-enabled crb && \
+    dnf -y install epel-release && \
+    dnf -y install ./R-${R_VERSION}-1-1.x86_64.rpm && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    dnf -y remove epel-release && \
+    dnf config-manager --set-disabled crb && \
+    dnf clean all
+
+CMD ["R"]

--- a/3.3/rockylinux9/docker-compose.test.yml
+++ b/3.3/rockylinux9/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/3.3/rockylinux9/hooks/post_push
+++ b/3.3/rockylinux9/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag 3.3.3-rockylinux9

--- a/3.4/opensuse154/Dockerfile
+++ b/3.4/opensuse154/Dockerfile
@@ -1,0 +1,22 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:opensuse154
+
+ARG R_VERSION=3.4.4
+ARG OS_IDENTIFIER=opensuse-154
+
+# Install R
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper --non-interactive --no-gpg-checks install ./R-${R_VERSION}-1-1.x86_64.rpm && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper clean --all
+
+CMD ["R"]

--- a/3.4/opensuse154/docker-compose.test.yml
+++ b/3.4/opensuse154/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/3.4/opensuse154/hooks/post_push
+++ b/3.4/opensuse154/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag 3.4.4-opensuse154

--- a/3.4/rockylinux9/Dockerfile
+++ b/3.4/rockylinux9/Dockerfile
@@ -1,0 +1,27 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:rockylinux9
+
+ARG R_VERSION=3.4.4
+ARG OS_IDENTIFIER=rhel-9
+
+# Install R
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    dnf -y install dnf-plugins-core && \
+    dnf config-manager --set-enabled crb && \
+    dnf -y install epel-release && \
+    dnf -y install ./R-${R_VERSION}-1-1.x86_64.rpm && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    dnf -y remove epel-release && \
+    dnf config-manager --set-disabled crb && \
+    dnf clean all
+
+CMD ["R"]

--- a/3.4/rockylinux9/docker-compose.test.yml
+++ b/3.4/rockylinux9/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/3.4/rockylinux9/hooks/post_push
+++ b/3.4/rockylinux9/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag 3.4.4-rockylinux9

--- a/3.5/opensuse154/Dockerfile
+++ b/3.5/opensuse154/Dockerfile
@@ -1,0 +1,22 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:opensuse154
+
+ARG R_VERSION=3.5.3
+ARG OS_IDENTIFIER=opensuse-154
+
+# Install R
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper --non-interactive --no-gpg-checks install ./R-${R_VERSION}-1-1.x86_64.rpm && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper clean --all
+
+CMD ["R"]

--- a/3.5/opensuse154/docker-compose.test.yml
+++ b/3.5/opensuse154/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/3.5/opensuse154/hooks/post_push
+++ b/3.5/opensuse154/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag 3.5.3-opensuse154

--- a/3.5/rockylinux9/Dockerfile
+++ b/3.5/rockylinux9/Dockerfile
@@ -1,0 +1,27 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:rockylinux9
+
+ARG R_VERSION=3.5.3
+ARG OS_IDENTIFIER=rhel-9
+
+# Install R
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    dnf -y install dnf-plugins-core && \
+    dnf config-manager --set-enabled crb && \
+    dnf -y install epel-release && \
+    dnf -y install ./R-${R_VERSION}-1-1.x86_64.rpm && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    dnf -y remove epel-release && \
+    dnf config-manager --set-disabled crb && \
+    dnf clean all
+
+CMD ["R"]

--- a/3.5/rockylinux9/docker-compose.test.yml
+++ b/3.5/rockylinux9/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/3.5/rockylinux9/hooks/post_push
+++ b/3.5/rockylinux9/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag 3.5.3-rockylinux9

--- a/3.6/opensuse154/Dockerfile
+++ b/3.6/opensuse154/Dockerfile
@@ -1,0 +1,22 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:opensuse154
+
+ARG R_VERSION=3.6.3
+ARG OS_IDENTIFIER=opensuse-154
+
+# Install R
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper --non-interactive --no-gpg-checks install ./R-${R_VERSION}-1-1.x86_64.rpm && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper clean --all
+
+CMD ["R"]

--- a/3.6/opensuse154/docker-compose.test.yml
+++ b/3.6/opensuse154/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/3.6/opensuse154/hooks/post_push
+++ b/3.6/opensuse154/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag 3.6.3-opensuse154

--- a/3.6/rockylinux9/Dockerfile
+++ b/3.6/rockylinux9/Dockerfile
@@ -1,0 +1,27 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:rockylinux9
+
+ARG R_VERSION=3.6.3
+ARG OS_IDENTIFIER=rhel-9
+
+# Install R
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    dnf -y install dnf-plugins-core && \
+    dnf config-manager --set-enabled crb && \
+    dnf -y install epel-release && \
+    dnf -y install ./R-${R_VERSION}-1-1.x86_64.rpm && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    dnf -y remove epel-release && \
+    dnf config-manager --set-disabled crb && \
+    dnf clean all
+
+CMD ["R"]

--- a/3.6/rockylinux9/docker-compose.test.yml
+++ b/3.6/rockylinux9/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/3.6/rockylinux9/hooks/post_push
+++ b/3.6/rockylinux9/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag 3.6.3-rockylinux9

--- a/4.0/opensuse154/Dockerfile
+++ b/4.0/opensuse154/Dockerfile
@@ -1,0 +1,22 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:opensuse154
+
+ARG R_VERSION=4.0.5
+ARG OS_IDENTIFIER=opensuse-154
+
+# Install R
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper --non-interactive --no-gpg-checks install ./R-${R_VERSION}-1-1.x86_64.rpm && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper clean --all
+
+CMD ["R"]

--- a/4.0/opensuse154/docker-compose.test.yml
+++ b/4.0/opensuse154/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/4.0/opensuse154/hooks/post_push
+++ b/4.0/opensuse154/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag 4.0.5-opensuse154

--- a/4.0/rockylinux9/Dockerfile
+++ b/4.0/rockylinux9/Dockerfile
@@ -1,0 +1,27 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:rockylinux9
+
+ARG R_VERSION=4.0.5
+ARG OS_IDENTIFIER=rhel-9
+
+# Install R
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    dnf -y install dnf-plugins-core && \
+    dnf config-manager --set-enabled crb && \
+    dnf -y install epel-release && \
+    dnf -y install ./R-${R_VERSION}-1-1.x86_64.rpm && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    dnf -y remove epel-release && \
+    dnf config-manager --set-disabled crb && \
+    dnf clean all
+
+CMD ["R"]

--- a/4.0/rockylinux9/docker-compose.test.yml
+++ b/4.0/rockylinux9/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/4.0/rockylinux9/hooks/post_push
+++ b/4.0/rockylinux9/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag 4.0.5-rockylinux9

--- a/4.1/opensuse154/Dockerfile
+++ b/4.1/opensuse154/Dockerfile
@@ -1,0 +1,22 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:opensuse154
+
+ARG R_VERSION=4.1.3
+ARG OS_IDENTIFIER=opensuse-154
+
+# Install R
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper --non-interactive --no-gpg-checks install ./R-${R_VERSION}-1-1.x86_64.rpm && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper clean --all
+
+CMD ["R"]

--- a/4.1/opensuse154/docker-compose.test.yml
+++ b/4.1/opensuse154/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/4.1/opensuse154/hooks/post_push
+++ b/4.1/opensuse154/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag 4.1.3-opensuse154

--- a/4.1/rockylinux9/Dockerfile
+++ b/4.1/rockylinux9/Dockerfile
@@ -1,0 +1,27 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:rockylinux9
+
+ARG R_VERSION=4.1.3
+ARG OS_IDENTIFIER=rhel-9
+
+# Install R
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    dnf -y install dnf-plugins-core && \
+    dnf config-manager --set-enabled crb && \
+    dnf -y install epel-release && \
+    dnf -y install ./R-${R_VERSION}-1-1.x86_64.rpm && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    dnf -y remove epel-release && \
+    dnf config-manager --set-disabled crb && \
+    dnf clean all
+
+CMD ["R"]

--- a/4.1/rockylinux9/docker-compose.test.yml
+++ b/4.1/rockylinux9/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/4.1/rockylinux9/hooks/post_push
+++ b/4.1/rockylinux9/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag 4.1.3-rockylinux9

--- a/4.2/opensuse154/Dockerfile
+++ b/4.2/opensuse154/Dockerfile
@@ -1,0 +1,22 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:opensuse154
+
+ARG R_VERSION=4.2.1
+ARG OS_IDENTIFIER=opensuse-154
+
+# Install R
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper --non-interactive --no-gpg-checks install ./R-${R_VERSION}-1-1.x86_64.rpm && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper clean --all
+
+CMD ["R"]

--- a/4.2/opensuse154/docker-compose.test.yml
+++ b/4.2/opensuse154/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/4.2/opensuse154/hooks/post_push
+++ b/4.2/opensuse154/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag 4.2.1-opensuse154

--- a/4.2/rockylinux9/Dockerfile
+++ b/4.2/rockylinux9/Dockerfile
@@ -1,0 +1,27 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:rockylinux9
+
+ARG R_VERSION=4.2.1
+ARG OS_IDENTIFIER=rhel-9
+
+# Install R
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    dnf -y install dnf-plugins-core && \
+    dnf config-manager --set-enabled crb && \
+    dnf -y install epel-release && \
+    dnf -y install ./R-${R_VERSION}-1-1.x86_64.rpm && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    dnf -y remove epel-release && \
+    dnf config-manager --set-disabled crb && \
+    dnf clean all
+
+CMD ["R"]

--- a/4.2/rockylinux9/docker-compose.test.yml
+++ b/4.2/rockylinux9/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/4.2/rockylinux9/hooks/post_push
+++ b/4.2/rockylinux9/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag 4.2.1-rockylinux9

--- a/Dockerfile-rockylinux.template
+++ b/Dockerfile-rockylinux.template
@@ -1,0 +1,21 @@
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:%%VARIANT%%
+
+ARG R_VERSION=%%R_VERSION%%
+ARG OS_IDENTIFIER=%%OS_IDENTIFIER%%
+
+# Install R
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    dnf -y install dnf-plugins-core && \
+    dnf config-manager --set-enabled crb && \
+    dnf -y install epel-release && \
+    dnf -y install ./R-${R_VERSION}-1-1.x86_64.rpm && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    dnf -y remove epel-release && \
+    dnf config-manager --set-disabled crb && \
+    dnf clean all
+
+CMD ["R"]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BASE_IMAGE ?= rstudio/r-base
 VERSIONS ?= 3.1 3.2 3.3 3.4 3.5 3.6 4.0 4.1 4.2 devel
-VARIANTS ?= bionic focal jammy centos7 rockylinux8 opensuse153
+VARIANTS ?= bionic focal jammy centos7 rockylinux8 rockylinux9 opensuse153 opensuse154
 
 # PATCH_VERSIONS defines all actively maintained R patch versions.
 PATCH_VERSIONS ?= 3.1.3 3.2.5 3.3.3 3.4.4 3.5.3 \

--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ The following distributions are supported:
 | jammy         | Ubuntu 22.04 |
 | centos7       | CentOS 7 |
 | rockylinux8   | Rocky Linux 8 |
+| rockylinux9   | Rocky Linux 9 |
 | opensuse153   | openSUSE 15.3 |
+| opensuse154   | openSUSE 15.4 |
 
 All minor versions of R since 3.1 are supported, on the latest patch release.
 

--- a/base/opensuse154/Dockerfile
+++ b/base/opensuse154/Dockerfile
@@ -1,0 +1,36 @@
+FROM opensuse/leap:15.4
+LABEL maintainer="RStudio Docker <docker@rstudio.com>"
+
+RUN zypper --non-interactive update
+RUN zypper --non-interactive --gpg-auto-import-keys install \
+    fontconfig \
+    gzip \
+    sudo \
+    tar \
+    vim \
+    wget \
+    && zypper clean --all
+
+# Install TinyTeX
+RUN wget -qO- "https://yihui.org/tinytex/install-bin-unix.sh" | sh && \
+    /root/.TinyTeX/bin/*/tlmgr path remove && \
+    mv /root/.TinyTeX/ /opt/TinyTeX && \
+    /opt/TinyTeX/bin/*/tlmgr option sys_bin /usr/local/bin && \
+    /opt/TinyTeX/bin/*/tlmgr path add
+
+# Install pandoc
+RUN mkdir -p /opt/pandoc && \
+    wget -O /opt/pandoc/pandoc.gz https://files.r-hub.io/pandoc/linux-64/pandoc.gz && \
+    gzip -d /opt/pandoc/pandoc.gz && \
+    chmod +x /opt/pandoc/pandoc && \
+    ln -s /opt/pandoc/pandoc /usr/bin/pandoc && \
+    wget -O /opt/pandoc/pandoc-citeproc.gz https://files.r-hub.io/pandoc/linux-64/pandoc-citeproc.gz && \
+    gzip -d /opt/pandoc/pandoc-citeproc.gz && \
+    chmod +x /opt/pandoc/pandoc-citeproc && \
+    ln -s /opt/pandoc/pandoc-citeproc /usr/bin/pandoc-citeproc
+
+# Set default locale
+ENV LANG C.UTF-8
+
+# Set default timezone
+ENV TZ UTC

--- a/base/rockylinux9/Dockerfile
+++ b/base/rockylinux9/Dockerfile
@@ -1,0 +1,36 @@
+FROM rockylinux:9
+LABEL maintainer="RStudio Docker <docker@rstudio.com>"
+
+RUN dnf -y update && \
+    dnf -y install \
+    fontconfig \
+    glibc-langpack-en \
+    perl-File-Find \
+    sudo \
+    vim \
+    wget && \
+    dnf clean all
+
+# Install TinyTeX
+RUN wget -qO- "https://yihui.org/tinytex/install-bin-unix.sh" | sh && \
+    /root/.TinyTeX/bin/*/tlmgr path remove && \
+    mv /root/.TinyTeX/ /opt/TinyTeX && \
+    /opt/TinyTeX/bin/*/tlmgr option sys_bin /usr/local/bin && \
+    /opt/TinyTeX/bin/*/tlmgr path add
+
+# Install pandoc
+RUN mkdir -p /opt/pandoc && \
+    wget -O /opt/pandoc/pandoc.gz https://files.r-hub.io/pandoc/linux-64/pandoc.gz && \
+    gzip -d /opt/pandoc/pandoc.gz && \
+    chmod +x /opt/pandoc/pandoc && \
+    ln -s /opt/pandoc/pandoc /usr/bin/pandoc && \
+    wget -O /opt/pandoc/pandoc-citeproc.gz https://files.r-hub.io/pandoc/linux-64/pandoc-citeproc.gz && \
+    gzip -d /opt/pandoc/pandoc-citeproc.gz && \
+    chmod +x /opt/pandoc/pandoc-citeproc && \
+    ln -s /opt/pandoc/pandoc-citeproc /usr/bin/pandoc-citeproc
+
+# Set default locale
+ENV LANG en_US.UTF-8
+
+# Set default timezone
+ENV TZ UTC

--- a/devel/opensuse154/Dockerfile
+++ b/devel/opensuse154/Dockerfile
@@ -1,0 +1,22 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:opensuse154
+
+ARG R_VERSION=devel
+ARG OS_IDENTIFIER=opensuse-154
+
+# Install R
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper --non-interactive --no-gpg-checks install ./R-${R_VERSION}-1-1.x86_64.rpm && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper clean --all
+
+CMD ["R"]

--- a/devel/opensuse154/docker-compose.test.yml
+++ b/devel/opensuse154/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/devel/opensuse154/hooks/post_push
+++ b/devel/opensuse154/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag devel-opensuse154

--- a/devel/rockylinux9/Dockerfile
+++ b/devel/rockylinux9/Dockerfile
@@ -1,0 +1,27 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:rockylinux9
+
+ARG R_VERSION=devel
+ARG OS_IDENTIFIER=rhel-9
+
+# Install R
+RUN wget https://cdn.rstudio.com/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    dnf -y install dnf-plugins-core && \
+    dnf config-manager --set-enabled crb && \
+    dnf -y install epel-release && \
+    dnf -y install ./R-${R_VERSION}-1-1.x86_64.rpm && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    dnf -y remove epel-release && \
+    dnf config-manager --set-disabled crb && \
+    dnf clean all
+
+CMD ["R"]

--- a/devel/rockylinux9/docker-compose.test.yml
+++ b/devel/rockylinux9/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/devel/rockylinux9/hooks/post_push
+++ b/devel/rockylinux9/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag devel-rockylinux9

--- a/update.sh
+++ b/update.sh
@@ -20,7 +20,9 @@ declare -A os_identifiers=(
     [jammy]='ubuntu-2204'
     [centos7]='centos-7'
     [rockylinux8]='centos-8'
+    [rockylinux9]='rhel-9'
     [opensuse153]='opensuse-153'
+    [opensuse154]='opensuse-154'
 )
 
 generated_warning() {
@@ -45,7 +47,9 @@ for version in "${!r_versions[@]}"; do
             ;;
             centos7|rockylinux8) template='centos'
             ;;
-            opensuse153) template='opensuse'
+            rockylinux9) template='rockylinux'
+            ;;
+            opensuse153|opensuse154) template='opensuse'
             ;;
         esac
 


### PR DESCRIPTION
Add images for Rocky Linux 9 and openSUSE 15.4. These were almost identical to the Rocky 8 and openSUSE 15.3 images, except for Rocky 9, the steps to install EPEL are slightly different (see https://github.com/rstudio/r-builds/#rhelcentos-linux).