### PR TITLE
Update GHA for set-output deprecation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
             variants="$(make print-variants)"
           fi
           variants=$(echo "$variants" | jq -R -c '[splits(" ")]')
-          echo "::set-output name=variants::$variants"
+          echo "variants=$variants" >> $GITHUB_OUTPUT
 
   docker-images:
     needs: setup-matrix


### PR DESCRIPTION
Update GHA for https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

(The opensuse154 failure is a known issue with failing R-devel builds)