### PR TITLE
Add images for Debian 11/12

### DIFF
--- a/3.1/bookworm/Dockerfile
+++ b/3.1/bookworm/Dockerfile
@@ -1,0 +1,23 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:bookworm
+
+ARG R_VERSION=3.1.3
+ARG OS_IDENTIFIER=debian-12
+
+# Install R
+RUN wget https://cdn.posit.co/r/${OS_IDENTIFIER}/pkgs/r-${R_VERSION}_1_amd64.deb && \
+    apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -f -y ./r-${R_VERSION}_1_amd64.deb && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm r-${R_VERSION}_1_amd64.deb && \
+    rm -rf /var/lib/apt/lists/*
+
+CMD ["R"]

--- a/3.1/bookworm/docker-compose.test.yml
+++ b/3.1/bookworm/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/3.1/bookworm/hooks/post_push
+++ b/3.1/bookworm/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag 3.1.3-bookworm

--- a/3.1/bullseye/Dockerfile
+++ b/3.1/bullseye/Dockerfile
@@ -1,0 +1,23 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:bullseye
+
+ARG R_VERSION=3.1.3
+ARG OS_IDENTIFIER=debian-11
+
+# Install R
+RUN wget https://cdn.posit.co/r/${OS_IDENTIFIER}/pkgs/r-${R_VERSION}_1_amd64.deb && \
+    apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -f -y ./r-${R_VERSION}_1_amd64.deb && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm r-${R_VERSION}_1_amd64.deb && \
+    rm -rf /var/lib/apt/lists/*
+
+CMD ["R"]

--- a/3.1/bullseye/docker-compose.test.yml
+++ b/3.1/bullseye/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/3.1/bullseye/hooks/post_push
+++ b/3.1/bullseye/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag 3.1.3-bullseye

--- a/3.2/bookworm/Dockerfile
+++ b/3.2/bookworm/Dockerfile
@@ -1,0 +1,23 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:bookworm
+
+ARG R_VERSION=3.2.5
+ARG OS_IDENTIFIER=debian-12
+
+# Install R
+RUN wget https://cdn.posit.co/r/${OS_IDENTIFIER}/pkgs/r-${R_VERSION}_1_amd64.deb && \
+    apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -f -y ./r-${R_VERSION}_1_amd64.deb && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm r-${R_VERSION}_1_amd64.deb && \
+    rm -rf /var/lib/apt/lists/*
+
+CMD ["R"]

--- a/3.2/bookworm/docker-compose.test.yml
+++ b/3.2/bookworm/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/3.2/bookworm/hooks/post_push
+++ b/3.2/bookworm/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag 3.2.5-bookworm

--- a/3.2/bullseye/Dockerfile
+++ b/3.2/bullseye/Dockerfile
@@ -1,0 +1,23 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:bullseye
+
+ARG R_VERSION=3.2.5
+ARG OS_IDENTIFIER=debian-11
+
+# Install R
+RUN wget https://cdn.posit.co/r/${OS_IDENTIFIER}/pkgs/r-${R_VERSION}_1_amd64.deb && \
+    apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -f -y ./r-${R_VERSION}_1_amd64.deb && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm r-${R_VERSION}_1_amd64.deb && \
+    rm -rf /var/lib/apt/lists/*
+
+CMD ["R"]

--- a/3.2/bullseye/docker-compose.test.yml
+++ b/3.2/bullseye/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/3.2/bullseye/hooks/post_push
+++ b/3.2/bullseye/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag 3.2.5-bullseye

--- a/3.3/bookworm/Dockerfile
+++ b/3.3/bookworm/Dockerfile
@@ -1,0 +1,23 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:bookworm
+
+ARG R_VERSION=3.3.3
+ARG OS_IDENTIFIER=debian-12
+
+# Install R
+RUN wget https://cdn.posit.co/r/${OS_IDENTIFIER}/pkgs/r-${R_VERSION}_1_amd64.deb && \
+    apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -f -y ./r-${R_VERSION}_1_amd64.deb && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm r-${R_VERSION}_1_amd64.deb && \
+    rm -rf /var/lib/apt/lists/*
+
+CMD ["R"]

--- a/3.3/bookworm/docker-compose.test.yml
+++ b/3.3/bookworm/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/3.3/bookworm/hooks/post_push
+++ b/3.3/bookworm/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag 3.3.3-bookworm

--- a/3.3/bullseye/Dockerfile
+++ b/3.3/bullseye/Dockerfile
@@ -1,0 +1,23 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:bullseye
+
+ARG R_VERSION=3.3.3
+ARG OS_IDENTIFIER=debian-11
+
+# Install R
+RUN wget https://cdn.posit.co/r/${OS_IDENTIFIER}/pkgs/r-${R_VERSION}_1_amd64.deb && \
+    apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -f -y ./r-${R_VERSION}_1_amd64.deb && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm r-${R_VERSION}_1_amd64.deb && \
+    rm -rf /var/lib/apt/lists/*
+
+CMD ["R"]

--- a/3.3/bullseye/docker-compose.test.yml
+++ b/3.3/bullseye/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/3.3/bullseye/hooks/post_push
+++ b/3.3/bullseye/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag 3.3.3-bullseye

--- a/3.4/bookworm/Dockerfile
+++ b/3.4/bookworm/Dockerfile
@@ -1,0 +1,23 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:bookworm
+
+ARG R_VERSION=3.4.4
+ARG OS_IDENTIFIER=debian-12
+
+# Install R
+RUN wget https://cdn.posit.co/r/${OS_IDENTIFIER}/pkgs/r-${R_VERSION}_1_amd64.deb && \
+    apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -f -y ./r-${R_VERSION}_1_amd64.deb && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm r-${R_VERSION}_1_amd64.deb && \
+    rm -rf /var/lib/apt/lists/*
+
+CMD ["R"]

--- a/3.4/bookworm/docker-compose.test.yml
+++ b/3.4/bookworm/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/3.4/bookworm/hooks/post_push
+++ b/3.4/bookworm/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag 3.4.4-bookworm

--- a/3.4/bullseye/Dockerfile
+++ b/3.4/bullseye/Dockerfile
@@ -1,0 +1,23 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:bullseye
+
+ARG R_VERSION=3.4.4
+ARG OS_IDENTIFIER=debian-11
+
+# Install R
+RUN wget https://cdn.posit.co/r/${OS_IDENTIFIER}/pkgs/r-${R_VERSION}_1_amd64.deb && \
+    apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -f -y ./r-${R_VERSION}_1_amd64.deb && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm r-${R_VERSION}_1_amd64.deb && \
+    rm -rf /var/lib/apt/lists/*
+
+CMD ["R"]

--- a/3.4/bullseye/docker-compose.test.yml
+++ b/3.4/bullseye/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/3.4/bullseye/hooks/post_push
+++ b/3.4/bullseye/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag 3.4.4-bullseye

--- a/3.5/bookworm/Dockerfile
+++ b/3.5/bookworm/Dockerfile
@@ -1,0 +1,23 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:bookworm
+
+ARG R_VERSION=3.5.3
+ARG OS_IDENTIFIER=debian-12
+
+# Install R
+RUN wget https://cdn.posit.co/r/${OS_IDENTIFIER}/pkgs/r-${R_VERSION}_1_amd64.deb && \
+    apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -f -y ./r-${R_VERSION}_1_amd64.deb && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm r-${R_VERSION}_1_amd64.deb && \
+    rm -rf /var/lib/apt/lists/*
+
+CMD ["R"]

--- a/3.5/bookworm/docker-compose.test.yml
+++ b/3.5/bookworm/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/3.5/bookworm/hooks/post_push
+++ b/3.5/bookworm/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag 3.5.3-bookworm

--- a/3.5/bullseye/Dockerfile
+++ b/3.5/bullseye/Dockerfile
@@ -1,0 +1,23 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:bullseye
+
+ARG R_VERSION=3.5.3
+ARG OS_IDENTIFIER=debian-11
+
+# Install R
+RUN wget https://cdn.posit.co/r/${OS_IDENTIFIER}/pkgs/r-${R_VERSION}_1_amd64.deb && \
+    apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -f -y ./r-${R_VERSION}_1_amd64.deb && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm r-${R_VERSION}_1_amd64.deb && \
+    rm -rf /var/lib/apt/lists/*
+
+CMD ["R"]

--- a/3.5/bullseye/docker-compose.test.yml
+++ b/3.5/bullseye/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/3.5/bullseye/hooks/post_push
+++ b/3.5/bullseye/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag 3.5.3-bullseye

--- a/3.6/bookworm/Dockerfile
+++ b/3.6/bookworm/Dockerfile
@@ -1,0 +1,23 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:bookworm
+
+ARG R_VERSION=3.6.3
+ARG OS_IDENTIFIER=debian-12
+
+# Install R
+RUN wget https://cdn.posit.co/r/${OS_IDENTIFIER}/pkgs/r-${R_VERSION}_1_amd64.deb && \
+    apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -f -y ./r-${R_VERSION}_1_amd64.deb && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm r-${R_VERSION}_1_amd64.deb && \
+    rm -rf /var/lib/apt/lists/*
+
+CMD ["R"]

--- a/3.6/bookworm/docker-compose.test.yml
+++ b/3.6/bookworm/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/3.6/bookworm/hooks/post_push
+++ b/3.6/bookworm/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag 3.6.3-bookworm

--- a/3.6/bullseye/Dockerfile
+++ b/3.6/bullseye/Dockerfile
@@ -1,0 +1,23 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:bullseye
+
+ARG R_VERSION=3.6.3
+ARG OS_IDENTIFIER=debian-11
+
+# Install R
+RUN wget https://cdn.posit.co/r/${OS_IDENTIFIER}/pkgs/r-${R_VERSION}_1_amd64.deb && \
+    apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -f -y ./r-${R_VERSION}_1_amd64.deb && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm r-${R_VERSION}_1_amd64.deb && \
+    rm -rf /var/lib/apt/lists/*
+
+CMD ["R"]

--- a/3.6/bullseye/docker-compose.test.yml
+++ b/3.6/bullseye/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/3.6/bullseye/hooks/post_push
+++ b/3.6/bullseye/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag 3.6.3-bullseye

--- a/4.0/bookworm/Dockerfile
+++ b/4.0/bookworm/Dockerfile
@@ -1,0 +1,23 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:bookworm
+
+ARG R_VERSION=4.0.5
+ARG OS_IDENTIFIER=debian-12
+
+# Install R
+RUN wget https://cdn.posit.co/r/${OS_IDENTIFIER}/pkgs/r-${R_VERSION}_1_amd64.deb && \
+    apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -f -y ./r-${R_VERSION}_1_amd64.deb && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm r-${R_VERSION}_1_amd64.deb && \
+    rm -rf /var/lib/apt/lists/*
+
+CMD ["R"]

--- a/4.0/bookworm/docker-compose.test.yml
+++ b/4.0/bookworm/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/4.0/bookworm/hooks/post_push
+++ b/4.0/bookworm/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag 4.0.5-bookworm

--- a/4.0/bullseye/Dockerfile
+++ b/4.0/bullseye/Dockerfile
@@ -1,0 +1,23 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:bullseye
+
+ARG R_VERSION=4.0.5
+ARG OS_IDENTIFIER=debian-11
+
+# Install R
+RUN wget https://cdn.posit.co/r/${OS_IDENTIFIER}/pkgs/r-${R_VERSION}_1_amd64.deb && \
+    apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -f -y ./r-${R_VERSION}_1_amd64.deb && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm r-${R_VERSION}_1_amd64.deb && \
+    rm -rf /var/lib/apt/lists/*
+
+CMD ["R"]

--- a/4.0/bullseye/docker-compose.test.yml
+++ b/4.0/bullseye/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/4.0/bullseye/hooks/post_push
+++ b/4.0/bullseye/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag 4.0.5-bullseye

--- a/4.1/bookworm/Dockerfile
+++ b/4.1/bookworm/Dockerfile
@@ -1,0 +1,23 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:bookworm
+
+ARG R_VERSION=4.1.3
+ARG OS_IDENTIFIER=debian-12
+
+# Install R
+RUN wget https://cdn.posit.co/r/${OS_IDENTIFIER}/pkgs/r-${R_VERSION}_1_amd64.deb && \
+    apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -f -y ./r-${R_VERSION}_1_amd64.deb && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm r-${R_VERSION}_1_amd64.deb && \
+    rm -rf /var/lib/apt/lists/*
+
+CMD ["R"]

--- a/4.1/bookworm/docker-compose.test.yml
+++ b/4.1/bookworm/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/4.1/bookworm/hooks/post_push
+++ b/4.1/bookworm/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag 4.1.3-bookworm

--- a/4.1/bullseye/Dockerfile
+++ b/4.1/bullseye/Dockerfile
@@ -1,0 +1,23 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:bullseye
+
+ARG R_VERSION=4.1.3
+ARG OS_IDENTIFIER=debian-11
+
+# Install R
+RUN wget https://cdn.posit.co/r/${OS_IDENTIFIER}/pkgs/r-${R_VERSION}_1_amd64.deb && \
+    apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -f -y ./r-${R_VERSION}_1_amd64.deb && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm r-${R_VERSION}_1_amd64.deb && \
+    rm -rf /var/lib/apt/lists/*
+
+CMD ["R"]

--- a/4.1/bullseye/docker-compose.test.yml
+++ b/4.1/bullseye/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/4.1/bullseye/hooks/post_push
+++ b/4.1/bullseye/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag 4.1.3-bullseye

--- a/4.2/bookworm/Dockerfile
+++ b/4.2/bookworm/Dockerfile
@@ -1,0 +1,23 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:bookworm
+
+ARG R_VERSION=4.2.3
+ARG OS_IDENTIFIER=debian-12
+
+# Install R
+RUN wget https://cdn.posit.co/r/${OS_IDENTIFIER}/pkgs/r-${R_VERSION}_1_amd64.deb && \
+    apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -f -y ./r-${R_VERSION}_1_amd64.deb && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm r-${R_VERSION}_1_amd64.deb && \
+    rm -rf /var/lib/apt/lists/*
+
+CMD ["R"]

--- a/4.2/bookworm/docker-compose.test.yml
+++ b/4.2/bookworm/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/4.2/bookworm/hooks/post_push
+++ b/4.2/bookworm/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag 4.2.3-bookworm

--- a/4.2/bullseye/Dockerfile
+++ b/4.2/bullseye/Dockerfile
@@ -1,0 +1,23 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:bullseye
+
+ARG R_VERSION=4.2.3
+ARG OS_IDENTIFIER=debian-11
+
+# Install R
+RUN wget https://cdn.posit.co/r/${OS_IDENTIFIER}/pkgs/r-${R_VERSION}_1_amd64.deb && \
+    apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -f -y ./r-${R_VERSION}_1_amd64.deb && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm r-${R_VERSION}_1_amd64.deb && \
+    rm -rf /var/lib/apt/lists/*
+
+CMD ["R"]

--- a/4.2/bullseye/docker-compose.test.yml
+++ b/4.2/bullseye/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/4.2/bullseye/hooks/post_push
+++ b/4.2/bullseye/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag 4.2.3-bullseye

--- a/4.3/bookworm/Dockerfile
+++ b/4.3/bookworm/Dockerfile
@@ -1,0 +1,23 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:bookworm
+
+ARG R_VERSION=4.3.1
+ARG OS_IDENTIFIER=debian-12
+
+# Install R
+RUN wget https://cdn.posit.co/r/${OS_IDENTIFIER}/pkgs/r-${R_VERSION}_1_amd64.deb && \
+    apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -f -y ./r-${R_VERSION}_1_amd64.deb && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm r-${R_VERSION}_1_amd64.deb && \
+    rm -rf /var/lib/apt/lists/*
+
+CMD ["R"]

--- a/4.3/bookworm/docker-compose.test.yml
+++ b/4.3/bookworm/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/4.3/bookworm/hooks/post_push
+++ b/4.3/bookworm/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag 4.3.1-bookworm

--- a/4.3/bullseye/Dockerfile
+++ b/4.3/bullseye/Dockerfile
@@ -1,0 +1,23 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:bullseye
+
+ARG R_VERSION=4.3.1
+ARG OS_IDENTIFIER=debian-11
+
+# Install R
+RUN wget https://cdn.posit.co/r/${OS_IDENTIFIER}/pkgs/r-${R_VERSION}_1_amd64.deb && \
+    apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -f -y ./r-${R_VERSION}_1_amd64.deb && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm r-${R_VERSION}_1_amd64.deb && \
+    rm -rf /var/lib/apt/lists/*
+
+CMD ["R"]

--- a/4.3/bullseye/docker-compose.test.yml
+++ b/4.3/bullseye/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/4.3/bullseye/hooks/post_push
+++ b/4.3/bullseye/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag 4.3.1-bullseye

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -1,0 +1,17 @@
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:%%VARIANT%%
+
+ARG R_VERSION=%%R_VERSION%%
+ARG OS_IDENTIFIER=%%OS_IDENTIFIER%%
+
+# Install R
+RUN wget https://cdn.posit.co/r/${OS_IDENTIFIER}/pkgs/r-${R_VERSION}_1_amd64.deb && \
+    apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -f -y ./r-${R_VERSION}_1_amd64.deb && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm r-${R_VERSION}_1_amd64.deb && \
+    rm -rf /var/lib/apt/lists/*
+
+CMD ["R"]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BASE_IMAGE ?= rstudio/r-base
 VERSIONS ?= 3.1 3.2 3.3 3.4 3.5 3.6 4.0 4.1 4.2 4.3 devel
-VARIANTS ?= bionic focal jammy centos7 rockylinux8 rockylinux9 opensuse154
+VARIANTS ?= bionic focal jammy bullseye bookworm centos7 rockylinux8 rockylinux9 opensuse154
 
 # PATCH_VERSIONS defines all actively maintained R patch versions.
 PATCH_VERSIONS ?= 3.1.3 3.2.5 3.3.3 3.4.4 3.5.3 \

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ The following distributions are supported:
 | bionic        | Ubuntu 18.04 |
 | focal         | Ubuntu 20.04 |
 | jammy         | Ubuntu 22.04 |
+| bullseye      | Debian 11 |
+| bookworm      | Debian 12 |
 | centos7       | CentOS 7 |
 | rockylinux8   | Rocky Linux 8 |
 | rockylinux9   | Rocky Linux 9 |

--- a/base/bookworm/Dockerfile
+++ b/base/bookworm/Dockerfile
@@ -1,0 +1,40 @@
+FROM debian:bookworm
+
+LABEL maintainer="Posit Docker <docker@posit.co>"
+
+RUN apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    apt-transport-https \
+    curl \
+    fontconfig \
+    libcurl4-openssl-dev \
+    locales \
+    perl \
+    sudo \
+    tzdata \
+    wget && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install TinyTeX
+RUN wget -qO- "https://yihui.org/tinytex/install-bin-unix.sh" | sh && \
+    /root/.TinyTeX/bin/*/tlmgr path remove && \
+    mv /root/.TinyTeX/ /opt/TinyTeX && \
+    /opt/TinyTeX/bin/*/tlmgr option sys_bin /usr/local/bin && \
+    /opt/TinyTeX/bin/*/tlmgr path add
+
+# Install pandoc
+RUN mkdir -p /opt/pandoc && \
+    wget -O /opt/pandoc/pandoc.gz https://files.r-hub.io/pandoc/linux-64/pandoc.gz && \
+    gzip -d /opt/pandoc/pandoc.gz && \
+    chmod +x /opt/pandoc/pandoc && \
+    ln -s /opt/pandoc/pandoc /usr/bin/pandoc && \
+    wget -O /opt/pandoc/pandoc-citeproc.gz https://files.r-hub.io/pandoc/linux-64/pandoc-citeproc.gz && \
+    gzip -d /opt/pandoc/pandoc-citeproc.gz && \
+    chmod +x /opt/pandoc/pandoc-citeproc && \
+    ln -s /opt/pandoc/pandoc-citeproc /usr/bin/pandoc-citeproc
+
+# Set default locale
+ENV LANG C.UTF-8
+
+# Set default timezone
+ENV TZ UTC

--- a/base/bullseye/Dockerfile
+++ b/base/bullseye/Dockerfile
@@ -1,0 +1,40 @@
+FROM debian:bullseye
+
+LABEL maintainer="Posit Docker <docker@posit.co>"
+
+RUN apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    apt-transport-https \
+    curl \
+    fontconfig \
+    libcurl4-openssl-dev \
+    locales \
+    perl \
+    sudo \
+    tzdata \
+    wget && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install TinyTeX
+RUN wget -qO- "https://yihui.org/tinytex/install-bin-unix.sh" | sh && \
+    /root/.TinyTeX/bin/*/tlmgr path remove && \
+    mv /root/.TinyTeX/ /opt/TinyTeX && \
+    /opt/TinyTeX/bin/*/tlmgr option sys_bin /usr/local/bin && \
+    /opt/TinyTeX/bin/*/tlmgr path add
+
+# Install pandoc
+RUN mkdir -p /opt/pandoc && \
+    wget -O /opt/pandoc/pandoc.gz https://files.r-hub.io/pandoc/linux-64/pandoc.gz && \
+    gzip -d /opt/pandoc/pandoc.gz && \
+    chmod +x /opt/pandoc/pandoc && \
+    ln -s /opt/pandoc/pandoc /usr/bin/pandoc && \
+    wget -O /opt/pandoc/pandoc-citeproc.gz https://files.r-hub.io/pandoc/linux-64/pandoc-citeproc.gz && \
+    gzip -d /opt/pandoc/pandoc-citeproc.gz && \
+    chmod +x /opt/pandoc/pandoc-citeproc && \
+    ln -s /opt/pandoc/pandoc-citeproc /usr/bin/pandoc-citeproc
+
+# Set default locale
+ENV LANG C.UTF-8
+
+# Set default timezone
+ENV TZ UTC

--- a/devel/bookworm/Dockerfile
+++ b/devel/bookworm/Dockerfile
@@ -1,0 +1,23 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:bookworm
+
+ARG R_VERSION=devel
+ARG OS_IDENTIFIER=debian-12
+
+# Install R
+RUN wget https://cdn.posit.co/r/${OS_IDENTIFIER}/pkgs/r-${R_VERSION}_1_amd64.deb && \
+    apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -f -y ./r-${R_VERSION}_1_amd64.deb && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm r-${R_VERSION}_1_amd64.deb && \
+    rm -rf /var/lib/apt/lists/*
+
+CMD ["R"]

--- a/devel/bookworm/docker-compose.test.yml
+++ b/devel/bookworm/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/devel/bookworm/hooks/post_push
+++ b/devel/bookworm/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag devel-bookworm

--- a/devel/bullseye/Dockerfile
+++ b/devel/bullseye/Dockerfile
@@ -1,0 +1,23 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:bullseye
+
+ARG R_VERSION=devel
+ARG OS_IDENTIFIER=debian-11
+
+# Install R
+RUN wget https://cdn.posit.co/r/${OS_IDENTIFIER}/pkgs/r-${R_VERSION}_1_amd64.deb && \
+    apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -f -y ./r-${R_VERSION}_1_amd64.deb && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm r-${R_VERSION}_1_amd64.deb && \
+    rm -rf /var/lib/apt/lists/*
+
+CMD ["R"]

--- a/devel/bullseye/docker-compose.test.yml
+++ b/devel/bullseye/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/devel/bullseye/hooks/post_push
+++ b/devel/bullseye/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag devel-bullseye

--- a/update.sh
+++ b/update.sh
@@ -19,6 +19,8 @@ declare -A os_identifiers=(
     [bionic]='ubuntu-1804'
     [focal]='ubuntu-2004'
     [jammy]='ubuntu-2204'
+    [bullseye]='debian-11'
+    [bookworm]='debian-12'
     [centos7]='centos-7'
     [rockylinux8]='centos-8'
     [rockylinux9]='rhel-9'
@@ -44,6 +46,8 @@ for version in "${!r_versions[@]}"; do
 
         case "$variant" in
             bionic|focal|jammy) template='ubuntu'
+            ;;
+            bullseye|bookworm) template='debian'
             ;;
             centos7|rockylinux8) template='centos'
             ;;


### PR DESCRIPTION
Add r-base images for Debian 11 (bullseye) and 12 (bookworm). These were identical to the Ubuntu images, so most of this was copy-paste.