### PR TITLE
Fix Pandoc install; Update to Pandoc 2.19.2

### DIFF
--- a/base/bookworm/Dockerfile
+++ b/base/bookworm/Dockerfile
@@ -22,16 +22,13 @@ RUN wget -qO- "https://yihui.org/tinytex/install-bin-unix.sh" | sh && \
     /opt/TinyTeX/bin/*/tlmgr option sys_bin /usr/local/bin && \
     /opt/TinyTeX/bin/*/tlmgr path add
 
-# Install pandoc
-RUN mkdir -p /opt/pandoc && \
-    wget -O /opt/pandoc/pandoc.gz https://files.r-hub.io/pandoc/linux-64/pandoc.gz && \
-    gzip -d /opt/pandoc/pandoc.gz && \
-    chmod +x /opt/pandoc/pandoc && \
-    ln -s /opt/pandoc/pandoc /usr/bin/pandoc && \
-    wget -O /opt/pandoc/pandoc-citeproc.gz https://files.r-hub.io/pandoc/linux-64/pandoc-citeproc.gz && \
-    gzip -d /opt/pandoc/pandoc-citeproc.gz && \
-    chmod +x /opt/pandoc/pandoc-citeproc && \
-    ln -s /opt/pandoc/pandoc-citeproc /usr/bin/pandoc-citeproc
+# Install Pandoc
+ARG PANDOC_VERSION=2.19.2
+RUN wget https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_VERSION}-linux-amd64.tar.gz -O pandoc.tar.gz && \
+    tar -xvf pandoc.tar.gz && \
+    mv pandoc-${PANDOC_VERSION} /opt/pandoc && \
+    ln -s /opt/pandoc/bin/pandoc /usr/local/bin/pandoc && \
+    rm pandoc.tar.gz
 
 # Set default locale
 ENV LANG C.UTF-8

--- a/base/bullseye/Dockerfile
+++ b/base/bullseye/Dockerfile
@@ -22,16 +22,13 @@ RUN wget -qO- "https://yihui.org/tinytex/install-bin-unix.sh" | sh && \
     /opt/TinyTeX/bin/*/tlmgr option sys_bin /usr/local/bin && \
     /opt/TinyTeX/bin/*/tlmgr path add
 
-# Install pandoc
-RUN mkdir -p /opt/pandoc && \
-    wget -O /opt/pandoc/pandoc.gz https://files.r-hub.io/pandoc/linux-64/pandoc.gz && \
-    gzip -d /opt/pandoc/pandoc.gz && \
-    chmod +x /opt/pandoc/pandoc && \
-    ln -s /opt/pandoc/pandoc /usr/bin/pandoc && \
-    wget -O /opt/pandoc/pandoc-citeproc.gz https://files.r-hub.io/pandoc/linux-64/pandoc-citeproc.gz && \
-    gzip -d /opt/pandoc/pandoc-citeproc.gz && \
-    chmod +x /opt/pandoc/pandoc-citeproc && \
-    ln -s /opt/pandoc/pandoc-citeproc /usr/bin/pandoc-citeproc
+# Install Pandoc
+ARG PANDOC_VERSION=2.19.2
+RUN wget https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_VERSION}-linux-amd64.tar.gz -O pandoc.tar.gz && \
+    tar -xvf pandoc.tar.gz && \
+    mv pandoc-${PANDOC_VERSION} /opt/pandoc && \
+    ln -s /opt/pandoc/bin/pandoc /usr/local/bin/pandoc && \
+    rm pandoc.tar.gz
 
 # Set default locale
 ENV LANG C.UTF-8

--- a/base/centos7/Dockerfile
+++ b/base/centos7/Dockerfile
@@ -17,16 +17,13 @@ RUN wget -qO- "https://yihui.org/tinytex/install-bin-unix.sh" | sh && \
     /opt/TinyTeX/bin/*/tlmgr option sys_bin /usr/local/bin && \
     /opt/TinyTeX/bin/*/tlmgr path add
 
-# Install pandoc
-RUN mkdir -p /opt/pandoc && \
-    wget -O /opt/pandoc/pandoc.gz https://files.r-hub.io/pandoc/linux-64/pandoc.gz && \
-    gzip -d /opt/pandoc/pandoc.gz && \
-    chmod +x /opt/pandoc/pandoc && \
-    ln -s /opt/pandoc/pandoc /usr/bin/pandoc && \
-    wget -O /opt/pandoc/pandoc-citeproc.gz https://files.r-hub.io/pandoc/linux-64/pandoc-citeproc.gz && \
-    gzip -d /opt/pandoc/pandoc-citeproc.gz && \
-    chmod +x /opt/pandoc/pandoc-citeproc && \
-    ln -s /opt/pandoc/pandoc-citeproc /usr/bin/pandoc-citeproc
+# Install Pandoc
+ARG PANDOC_VERSION=2.19.2
+RUN wget https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_VERSION}-linux-amd64.tar.gz -O pandoc.tar.gz && \
+    tar -xvf pandoc.tar.gz && \
+    mv pandoc-${PANDOC_VERSION} /opt/pandoc && \
+    ln -s /opt/pandoc/bin/pandoc /usr/local/bin/pandoc && \
+    rm pandoc.tar.gz
 
 # Set default locale
 ENV LANG en_US.UTF-8

--- a/base/focal/Dockerfile
+++ b/base/focal/Dockerfile
@@ -22,16 +22,13 @@ RUN wget -qO- "https://yihui.org/tinytex/install-bin-unix.sh" | sh && \
     /opt/TinyTeX/bin/*/tlmgr option sys_bin /usr/local/bin && \
     /opt/TinyTeX/bin/*/tlmgr path add
 
-# Install pandoc
-RUN mkdir -p /opt/pandoc && \
-    wget -O /opt/pandoc/pandoc.gz https://files.r-hub.io/pandoc/linux-64/pandoc.gz && \
-    gzip -d /opt/pandoc/pandoc.gz && \
-    chmod +x /opt/pandoc/pandoc && \
-    ln -s /opt/pandoc/pandoc /usr/bin/pandoc && \
-    wget -O /opt/pandoc/pandoc-citeproc.gz https://files.r-hub.io/pandoc/linux-64/pandoc-citeproc.gz && \
-    gzip -d /opt/pandoc/pandoc-citeproc.gz && \
-    chmod +x /opt/pandoc/pandoc-citeproc && \
-    ln -s /opt/pandoc/pandoc-citeproc /usr/bin/pandoc-citeproc
+# Install Pandoc
+ARG PANDOC_VERSION=2.19.2
+RUN wget https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_VERSION}-linux-amd64.tar.gz -O pandoc.tar.gz && \
+    tar -xvf pandoc.tar.gz && \
+    mv pandoc-${PANDOC_VERSION} /opt/pandoc && \
+    ln -s /opt/pandoc/bin/pandoc /usr/local/bin/pandoc && \
+    rm pandoc.tar.gz
 
 # Set default locale
 ENV LANG C.UTF-8

--- a/base/jammy/Dockerfile
+++ b/base/jammy/Dockerfile
@@ -22,16 +22,13 @@ RUN wget -qO- "https://yihui.org/tinytex/install-bin-unix.sh" | sh && \
     /opt/TinyTeX/bin/*/tlmgr option sys_bin /usr/local/bin && \
     /opt/TinyTeX/bin/*/tlmgr path add
 
-# Install pandoc
-RUN mkdir -p /opt/pandoc && \
-    wget -O /opt/pandoc/pandoc.gz https://files.r-hub.io/pandoc/linux-64/pandoc.gz && \
-    gzip -d /opt/pandoc/pandoc.gz && \
-    chmod +x /opt/pandoc/pandoc && \
-    ln -s /opt/pandoc/pandoc /usr/bin/pandoc && \
-    wget -O /opt/pandoc/pandoc-citeproc.gz https://files.r-hub.io/pandoc/linux-64/pandoc-citeproc.gz && \
-    gzip -d /opt/pandoc/pandoc-citeproc.gz && \
-    chmod +x /opt/pandoc/pandoc-citeproc && \
-    ln -s /opt/pandoc/pandoc-citeproc /usr/bin/pandoc-citeproc
+# Install Pandoc
+ARG PANDOC_VERSION=2.19.2
+RUN wget https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_VERSION}-linux-amd64.tar.gz -O pandoc.tar.gz && \
+    tar -xvf pandoc.tar.gz && \
+    mv pandoc-${PANDOC_VERSION} /opt/pandoc && \
+    ln -s /opt/pandoc/bin/pandoc /usr/local/bin/pandoc && \
+    rm pandoc.tar.gz
 
 # Set default locale
 ENV LANG C.UTF-8

--- a/base/opensuse154/Dockerfile
+++ b/base/opensuse154/Dockerfile
@@ -18,16 +18,13 @@ RUN wget -qO- "https://yihui.org/tinytex/install-bin-unix.sh" | sh && \
     /opt/TinyTeX/bin/*/tlmgr option sys_bin /usr/local/bin && \
     /opt/TinyTeX/bin/*/tlmgr path add
 
-# Install pandoc
-RUN mkdir -p /opt/pandoc && \
-    wget -O /opt/pandoc/pandoc.gz https://files.r-hub.io/pandoc/linux-64/pandoc.gz && \
-    gzip -d /opt/pandoc/pandoc.gz && \
-    chmod +x /opt/pandoc/pandoc && \
-    ln -s /opt/pandoc/pandoc /usr/bin/pandoc && \
-    wget -O /opt/pandoc/pandoc-citeproc.gz https://files.r-hub.io/pandoc/linux-64/pandoc-citeproc.gz && \
-    gzip -d /opt/pandoc/pandoc-citeproc.gz && \
-    chmod +x /opt/pandoc/pandoc-citeproc && \
-    ln -s /opt/pandoc/pandoc-citeproc /usr/bin/pandoc-citeproc
+# Install Pandoc
+ARG PANDOC_VERSION=2.19.2
+RUN wget https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_VERSION}-linux-amd64.tar.gz -O pandoc.tar.gz && \
+    tar -xvf pandoc.tar.gz && \
+    mv pandoc-${PANDOC_VERSION} /opt/pandoc && \
+    ln -s /opt/pandoc/bin/pandoc /usr/local/bin/pandoc && \
+    rm pandoc.tar.gz
 
 # Set default locale
 ENV LANG C.UTF-8

--- a/base/opensuse155/Dockerfile
+++ b/base/opensuse155/Dockerfile
@@ -18,16 +18,13 @@ RUN wget -qO- "https://yihui.org/tinytex/install-bin-unix.sh" | sh && \
     /opt/TinyTeX/bin/*/tlmgr option sys_bin /usr/local/bin && \
     /opt/TinyTeX/bin/*/tlmgr path add
 
-# Install pandoc
-RUN mkdir -p /opt/pandoc && \
-    wget -O /opt/pandoc/pandoc.gz https://files.r-hub.io/pandoc/linux-64/pandoc.gz && \
-    gzip -d /opt/pandoc/pandoc.gz && \
-    chmod +x /opt/pandoc/pandoc && \
-    ln -s /opt/pandoc/pandoc /usr/bin/pandoc && \
-    wget -O /opt/pandoc/pandoc-citeproc.gz https://files.r-hub.io/pandoc/linux-64/pandoc-citeproc.gz && \
-    gzip -d /opt/pandoc/pandoc-citeproc.gz && \
-    chmod +x /opt/pandoc/pandoc-citeproc && \
-    ln -s /opt/pandoc/pandoc-citeproc /usr/bin/pandoc-citeproc
+# Install Pandoc
+ARG PANDOC_VERSION=2.19.2
+RUN wget https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_VERSION}-linux-amd64.tar.gz -O pandoc.tar.gz && \
+    tar -xvf pandoc.tar.gz && \
+    mv pandoc-${PANDOC_VERSION} /opt/pandoc && \
+    ln -s /opt/pandoc/bin/pandoc /usr/local/bin/pandoc && \
+    rm pandoc.tar.gz
 
 # Set default locale
 ENV LANG C.UTF-8

--- a/base/rockylinux8/Dockerfile
+++ b/base/rockylinux8/Dockerfile
@@ -19,16 +19,13 @@ RUN wget -qO- "https://yihui.org/tinytex/install-bin-unix.sh" | sh && \
     /opt/TinyTeX/bin/*/tlmgr option sys_bin /usr/local/bin && \
     /opt/TinyTeX/bin/*/tlmgr path add
 
-# Install pandoc
-RUN mkdir -p /opt/pandoc && \
-    wget -O /opt/pandoc/pandoc.gz https://files.r-hub.io/pandoc/linux-64/pandoc.gz && \
-    gzip -d /opt/pandoc/pandoc.gz && \
-    chmod +x /opt/pandoc/pandoc && \
-    ln -s /opt/pandoc/pandoc /usr/bin/pandoc && \
-    wget -O /opt/pandoc/pandoc-citeproc.gz https://files.r-hub.io/pandoc/linux-64/pandoc-citeproc.gz && \
-    gzip -d /opt/pandoc/pandoc-citeproc.gz && \
-    chmod +x /opt/pandoc/pandoc-citeproc && \
-    ln -s /opt/pandoc/pandoc-citeproc /usr/bin/pandoc-citeproc
+# Install Pandoc
+ARG PANDOC_VERSION=2.19.2
+RUN wget https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_VERSION}-linux-amd64.tar.gz -O pandoc.tar.gz && \
+    tar -xvf pandoc.tar.gz && \
+    mv pandoc-${PANDOC_VERSION} /opt/pandoc && \
+    ln -s /opt/pandoc/bin/pandoc /usr/local/bin/pandoc && \
+    rm pandoc.tar.gz
 
 # Set default locale
 ENV LANG en_US.UTF-8

--- a/base/rockylinux9/Dockerfile
+++ b/base/rockylinux9/Dockerfile
@@ -18,16 +18,13 @@ RUN wget -qO- "https://yihui.org/tinytex/install-bin-unix.sh" | sh && \
     /opt/TinyTeX/bin/*/tlmgr option sys_bin /usr/local/bin && \
     /opt/TinyTeX/bin/*/tlmgr path add
 
-# Install pandoc
-RUN mkdir -p /opt/pandoc && \
-    wget -O /opt/pandoc/pandoc.gz https://files.r-hub.io/pandoc/linux-64/pandoc.gz && \
-    gzip -d /opt/pandoc/pandoc.gz && \
-    chmod +x /opt/pandoc/pandoc && \
-    ln -s /opt/pandoc/pandoc /usr/bin/pandoc && \
-    wget -O /opt/pandoc/pandoc-citeproc.gz https://files.r-hub.io/pandoc/linux-64/pandoc-citeproc.gz && \
-    gzip -d /opt/pandoc/pandoc-citeproc.gz && \
-    chmod +x /opt/pandoc/pandoc-citeproc && \
-    ln -s /opt/pandoc/pandoc-citeproc /usr/bin/pandoc-citeproc
+# Install Pandoc
+ARG PANDOC_VERSION=2.19.2
+RUN wget https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_VERSION}-linux-amd64.tar.gz -O pandoc.tar.gz && \
+    tar -xvf pandoc.tar.gz && \
+    mv pandoc-${PANDOC_VERSION} /opt/pandoc && \
+    ln -s /opt/pandoc/bin/pandoc /usr/local/bin/pandoc && \
+    rm pandoc.tar.gz
 
 # Set default locale
 ENV LANG en_US.UTF-8

--- a/test/test.sh
+++ b/test/test.sh
@@ -28,6 +28,7 @@ Rscript $DIR/testpkg/tests/test.R
 
 # Check that TinyTeX and Pandoc were installed correctly
 tlmgr --version
+pandoc --version
 echo -e '# Title\ncontent' | pandoc --output $DIR/test.pdf
 rm $DIR/test.pdf
 


### PR DESCRIPTION
Pandoc 1 is old and no longer available from R-Hub. System Pandoc versions all differ from 1.x to 2.x, so install the final Pandoc 2.x static binaries from https://github.com/jgm/pandoc/releases/tag/2.19.2. pandoc-citeproc is no longer needed. We don't expect any breaking changes moving from Pandoc 1 to 2 here.

Here are the system pandoc versions for reference:
    - focal: 2.5
    - jammy: 2.9.2
    - centos7: 1.12.3
    - rockylinux8: 2.0.6 (powertools)
    - rockylinux9: 2.14.0 (EPEL)
    - opensuse154: 2.17
    - opensuse155: 2.18