### PR TITLE
Add R-next images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BASE_IMAGE ?= rstudio/r-base
-VERSIONS ?= 3.1 3.2 3.3 3.4 3.5 3.6 4.0 4.1 4.2 4.3 4.4 devel
+VERSIONS ?= 3.1 3.2 3.3 3.4 3.5 3.6 4.0 4.1 4.2 4.3 4.4 devel next
 VARIANTS ?= focal jammy noble bullseye bookworm centos7 rockylinux8 rockylinux9 opensuse154 opensuse155
 
 # PATCH_VERSIONS defines all actively maintained R patch versions.

--- a/next/bookworm/Dockerfile
+++ b/next/bookworm/Dockerfile
@@ -1,0 +1,23 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:bookworm
+
+ARG R_VERSION=next
+ARG OS_IDENTIFIER=debian-12
+
+# Install R
+RUN wget https://cdn.posit.co/r/${OS_IDENTIFIER}/pkgs/r-${R_VERSION}_1_amd64.deb && \
+    apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -f -y ./r-${R_VERSION}_1_amd64.deb && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm r-${R_VERSION}_1_amd64.deb && \
+    rm -rf /var/lib/apt/lists/*
+
+CMD ["R"]

--- a/next/bookworm/docker-compose.test.yml
+++ b/next/bookworm/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/next/bookworm/hooks/post_push
+++ b/next/bookworm/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag next-bookworm

--- a/next/bullseye/Dockerfile
+++ b/next/bullseye/Dockerfile
@@ -1,0 +1,23 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:bullseye
+
+ARG R_VERSION=next
+ARG OS_IDENTIFIER=debian-11
+
+# Install R
+RUN wget https://cdn.posit.co/r/${OS_IDENTIFIER}/pkgs/r-${R_VERSION}_1_amd64.deb && \
+    apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -f -y ./r-${R_VERSION}_1_amd64.deb && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm r-${R_VERSION}_1_amd64.deb && \
+    rm -rf /var/lib/apt/lists/*
+
+CMD ["R"]

--- a/next/bullseye/docker-compose.test.yml
+++ b/next/bullseye/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/next/bullseye/hooks/post_push
+++ b/next/bullseye/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag next-bullseye

--- a/next/centos7/Dockerfile
+++ b/next/centos7/Dockerfile
@@ -1,0 +1,24 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:centos7
+
+ARG R_VERSION=next
+ARG OS_IDENTIFIER=centos-7
+
+# Install R
+RUN wget https://cdn.posit.co/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    yum -y install epel-release && \
+    yum -y install ./R-${R_VERSION}-1-1.x86_64.rpm && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    yum -y remove epel-release && \
+    yum clean all
+
+CMD ["R"]

--- a/next/centos7/docker-compose.test.yml
+++ b/next/centos7/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/next/centos7/hooks/post_push
+++ b/next/centos7/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag next-centos7

--- a/next/focal/Dockerfile
+++ b/next/focal/Dockerfile
@@ -1,0 +1,23 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:focal
+
+ARG R_VERSION=next
+ARG OS_IDENTIFIER=ubuntu-2004
+
+# Install R
+RUN wget https://cdn.posit.co/r/${OS_IDENTIFIER}/pkgs/r-${R_VERSION}_1_amd64.deb && \
+    apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -f -y ./r-${R_VERSION}_1_amd64.deb && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm r-${R_VERSION}_1_amd64.deb && \
+    rm -rf /var/lib/apt/lists/*
+
+CMD ["R"]

--- a/next/focal/docker-compose.test.yml
+++ b/next/focal/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/next/focal/hooks/post_push
+++ b/next/focal/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag next-focal

--- a/next/jammy/Dockerfile
+++ b/next/jammy/Dockerfile
@@ -1,0 +1,23 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:jammy
+
+ARG R_VERSION=next
+ARG OS_IDENTIFIER=ubuntu-2204
+
+# Install R
+RUN wget https://cdn.posit.co/r/${OS_IDENTIFIER}/pkgs/r-${R_VERSION}_1_amd64.deb && \
+    apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -f -y ./r-${R_VERSION}_1_amd64.deb && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm r-${R_VERSION}_1_amd64.deb && \
+    rm -rf /var/lib/apt/lists/*
+
+CMD ["R"]

--- a/next/jammy/docker-compose.test.yml
+++ b/next/jammy/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/next/jammy/hooks/post_push
+++ b/next/jammy/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag next-jammy

--- a/next/noble/Dockerfile
+++ b/next/noble/Dockerfile
@@ -1,0 +1,23 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:noble
+
+ARG R_VERSION=next
+ARG OS_IDENTIFIER=ubuntu-2404
+
+# Install R
+RUN wget https://cdn.posit.co/r/${OS_IDENTIFIER}/pkgs/r-${R_VERSION}_1_amd64.deb && \
+    apt-get update -qq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -f -y ./r-${R_VERSION}_1_amd64.deb && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm r-${R_VERSION}_1_amd64.deb && \
+    rm -rf /var/lib/apt/lists/*
+
+CMD ["R"]

--- a/next/noble/docker-compose.test.yml
+++ b/next/noble/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/next/noble/hooks/post_push
+++ b/next/noble/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag next-noble

--- a/next/opensuse154/Dockerfile
+++ b/next/opensuse154/Dockerfile
@@ -1,0 +1,22 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:opensuse154
+
+ARG R_VERSION=next
+ARG OS_IDENTIFIER=opensuse-154
+
+# Install R
+RUN wget https://cdn.posit.co/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper --non-interactive --no-gpg-checks install ./R-${R_VERSION}-1-1.x86_64.rpm && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper clean --all
+
+CMD ["R"]

--- a/next/opensuse154/docker-compose.test.yml
+++ b/next/opensuse154/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/next/opensuse154/hooks/post_push
+++ b/next/opensuse154/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag next-opensuse154

--- a/next/opensuse155/Dockerfile
+++ b/next/opensuse155/Dockerfile
@@ -1,0 +1,22 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:opensuse155
+
+ARG R_VERSION=next
+ARG OS_IDENTIFIER=opensuse-155
+
+# Install R
+RUN wget https://cdn.posit.co/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper --non-interactive --no-gpg-checks install ./R-${R_VERSION}-1-1.x86_64.rpm && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    zypper clean --all
+
+CMD ["R"]

--- a/next/opensuse155/docker-compose.test.yml
+++ b/next/opensuse155/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/next/opensuse155/hooks/post_push
+++ b/next/opensuse155/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag next-opensuse155

--- a/next/rockylinux8/Dockerfile
+++ b/next/rockylinux8/Dockerfile
@@ -1,0 +1,24 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:rockylinux8
+
+ARG R_VERSION=next
+ARG OS_IDENTIFIER=centos-8
+
+# Install R
+RUN wget https://cdn.posit.co/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    yum -y install epel-release && \
+    yum -y install ./R-${R_VERSION}-1-1.x86_64.rpm && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    yum -y remove epel-release && \
+    yum clean all
+
+CMD ["R"]

--- a/next/rockylinux8/docker-compose.test.yml
+++ b/next/rockylinux8/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/next/rockylinux8/hooks/post_push
+++ b/next/rockylinux8/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag next-rockylinux8

--- a/next/rockylinux9/Dockerfile
+++ b/next/rockylinux9/Dockerfile
@@ -1,0 +1,27 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "update.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+ARG BASE_IMAGE=rstudio/r-base
+FROM ${BASE_IMAGE}:rockylinux9
+
+ARG R_VERSION=next
+ARG OS_IDENTIFIER=rhel-9
+
+# Install R
+RUN wget https://cdn.posit.co/r/${OS_IDENTIFIER}/pkgs/R-${R_VERSION}-1-1.x86_64.rpm && \
+    dnf -y install dnf-plugins-core && \
+    dnf config-manager --set-enabled crb && \
+    dnf -y install epel-release && \
+    dnf -y install ./R-${R_VERSION}-1-1.x86_64.rpm && \
+    ln -s /opt/R/${R_VERSION}/bin/R /usr/bin/R && \
+    ln -s /opt/R/${R_VERSION}/bin/Rscript /usr/bin/Rscript && \
+    ln -s /opt/R/${R_VERSION}/lib/R /usr/lib/R && \
+    rm R-${R_VERSION}-1-1.x86_64.rpm && \
+    dnf -y remove epel-release && \
+    dnf config-manager --set-disabled crb && \
+    dnf clean all
+
+CMD ["R"]

--- a/next/rockylinux9/docker-compose.test.yml
+++ b/next/rockylinux9/docker-compose.test.yml
@@ -1,0 +1,5 @@
+sut:
+  build: .
+  volumes:
+    - ../../test:/test
+  command: /test/test.sh

--- a/next/rockylinux9/hooks/post_push
+++ b/next/rockylinux9/hooks/post_push
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function add_tag() {
+    docker tag $IMAGE_NAME $DOCKER_REPO:$1
+    docker push $DOCKER_REPO:$1
+}
+
+add_tag next-rockylinux9

--- a/test/test.sh
+++ b/test/test.sh
@@ -8,7 +8,7 @@ Rscript -e 'sessionInfo()'
 
 # Ensure that the R version in the Docker tag (x.y or x.y.z) matches the image
 r_ver=$(Rscript -e 'cat(as.character(getRversion()))')
-if [[ "$TAG_VERSION" != "devel" ]] && [[ ! "$r_ver" =~ ^"$TAG_VERSION" ]]; then
+if [[ "$TAG_VERSION" != "devel" ]] && [[ "$TAG_VERSION" != "next" ]] && [[ ! "$r_ver" =~ ^"$TAG_VERSION" ]]; then
     echo "R version $r_ver does not match Docker tag version $TAG_VERSION"
     exit 1
 fi

--- a/update.sh
+++ b/update.sh
@@ -14,6 +14,7 @@ declare -A r_versions=(
     [4.3]='4.3.3'
     [4.4]='4.4.0'
     [devel]='devel'
+    [next]='next'
 )
 
 declare -A os_identifiers=(


### PR DESCRIPTION
Add `R-next` images, similar to how we have `R-devel` images. `R-next` is the next version of R which switches from alpha to beta to RC, added to the R builds a while back: https://github.com/rstudio/r-builds/pull/116

It's useful for testing minor R version releases before the release day, and I've been using these locally for R 4.4.0 testing. So adding these images, but not documenting them or enabling daily builds for them. When needed for testing, they can be rebuilt on demand with the GHA workflow.