### PR TITLE
Fix CentOS 7 builds; Use vault.centos.org on CentOS 7 for EOL

### DIFF
--- a/base/centos7/Dockerfile
+++ b/base/centos7/Dockerfile
@@ -1,6 +1,9 @@
 FROM centos:centos7
 LABEL maintainer="Posit Docker <docker@posit.co>"
 
+# Use vault.centos.org since CentOS 7 is EOL and the official mirrors are no longer available
+RUN sed -i -e 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/*
+
 RUN yum -y update && \
     yum -y install \
     fontconfig \


### PR DESCRIPTION
Fix the daily R-devel builds for CentOS 7, use vault for mirrors since CentOS 7 is now EOL.