### PR TITLE
Fix R-devel tests, fix R API calls for R 4.5.0 R_NO_REMAP changes

### DIFF
--- a/test/testpkg/src/add.c
+++ b/test/testpkg/src/add.c
@@ -3,8 +3,8 @@
 
 SEXP add(SEXP a, SEXP b)
 {
-  SEXP result = PROTECT(allocVector(REALSXP, 1));
-  REAL(result)[0] = asReal(a) + asReal(b);
+  SEXP result = PROTECT(Rf_allocVector(REALSXP, 1));
+  REAL(result)[0] = Rf_asReal(a) + Rf_asReal(b);
   UNPROTECT(1);
   return result;
 }

--- a/test/testpkg/src/subtract.cpp
+++ b/test/testpkg/src/subtract.cpp
@@ -3,8 +3,8 @@
 
 extern "C" SEXP subtract(SEXP a, SEXP b)
 {
-  SEXP result = PROTECT(allocVector(REALSXP, 1));
-  REAL(result)[0] = asReal(a) - asReal(b);
+  SEXP result = PROTECT(Rf_allocVector(REALSXP, 1));
+  REAL(result)[0] = Rf_asReal(a) - Rf_asReal(b);
   UNPROTECT(1);
   return result;
 }


### PR DESCRIPTION
These tests have been failing since November:
```r
g++ -std=gnu++11 -I"/opt/R/devel/lib/R/include" -DNDEBUG   -I/usr/local/include    -fpic  -g -O2  -DR_NO_REMAP -c subtract.cpp -o subtract.o
In file included from subtract.cpp:2:
subtract.cpp: In function ‘SEXPREC* subtract(SEXP, SEXP)’:
subtract.cpp:6:25: error: ‘allocVector’ was not declared in this scope; did you mean ‘Rf_allocVector’?
    6 |   SEXP result = PROTECT(allocVector(REALSXP, 1));
      |                         ^~~~~~~~~~~
/opt/R/devel/lib/R/include/Rinternals.h:388:36: note: in definition of macro ‘PROTECT’
  388 | #define PROTECT(s)      Rf_protect(s)
      |                                    ^
subtract.cpp:7:21: error: ‘asReal’ was not declared in this scope
    7 |   REAL(result)[0] = asReal(a) - asReal(b);
      |                     ^~~~~~
make: *** [/opt/R/devel/lib/R/etc/Makeconf:204: subtract.o] Error 1
```