### PR TITLE
chore: rstudio/r-base to posit/r-base

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,7 +95,7 @@ jobs:
           driver: docker
           install: true
 
-      - name: Login to DockerHub
+      - name: Login to Posit DockerHub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -119,7 +119,18 @@ jobs:
         run: |
           make test-all
 
-      - name: Push images
+      - name: Push Posit images
         if: ${{ github.ref == 'refs/heads/main' || inputs.publish_images }}
         run: |
           make push-all
+
+      - name: Login to RStudio DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.RSTUDIO_DOCKERHUB_USERNAME }}
+          password: ${{ secrets.RSTUDIO_DOCKERHUB_TOKEN }}
+
+      - name: Push RStudio images
+        if: ${{ github.ref == 'refs/heads/main' || inputs.publish_images }}
+        run: |
+          make push-all-rstudio

--- a/Dockerfile-centos.template
+++ b/Dockerfile-centos.template
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=rstudio/r-base
+ARG BASE_IMAGE=posit/r-base
 FROM ${BASE_IMAGE}:%%VARIANT%%
 
 ARG R_VERSION=%%R_VERSION%%

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=rstudio/r-base
+ARG BASE_IMAGE=posit/r-base
 FROM ${BASE_IMAGE}:%%VARIANT%%
 
 ARG R_VERSION=%%R_VERSION%%

--- a/Dockerfile-opensuse.template
+++ b/Dockerfile-opensuse.template
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=rstudio/r-base
+ARG BASE_IMAGE=posit/r-base
 FROM ${BASE_IMAGE}:%%VARIANT%%
 
 ARG R_VERSION=%%R_VERSION%%

--- a/Dockerfile-rockylinux.template
+++ b/Dockerfile-rockylinux.template
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=rstudio/r-base
+ARG BASE_IMAGE=posit/r-base
 FROM ${BASE_IMAGE}:%%VARIANT%%
 
 ARG R_VERSION=%%R_VERSION%%

--- a/Dockerfile-ubuntu.template
+++ b/Dockerfile-ubuntu.template
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=rstudio/r-base
+ARG BASE_IMAGE=posit/r-base
 FROM ${BASE_IMAGE}:%%VARIANT%%
 
 ARG R_VERSION=%%R_VERSION%%

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-BASE_IMAGE ?= rstudio/r-base
+BASE_IMAGE ?= posit/r-base
+BASE_IMAGE_RSTUDIO ?= rstudio/r-base
 VERSIONS ?= 3.1 3.2 3.3 3.4 3.5 3.6 4.0 4.1 4.2 4.3 4.4 devel next
 VARIANTS ?= focal jammy noble bullseye bookworm centos7 rockylinux8 rockylinux9 opensuse155 opensuse156
 
@@ -60,6 +61,10 @@ push-$(version)-$(variant):
 	docker push $(BASE_IMAGE):$(version)-$(variant)
 	IMAGE_NAME=$(BASE_IMAGE):$(version)-$(variant) DOCKER_REPO=$(BASE_IMAGE) bash ./$(version)/$(variant)/hooks/post_push
 
+push-rstudio-$(version)-$(variant):
+	docker push $(BASE_IMAGE_RSTUDIO):$(version)-$(variant)
+	IMAGE_NAME=$(BASE_IMAGE_RSTUDIO):$(version)-$(variant) DOCKER_REPO=$(BASE_IMAGE_RSTUDIO) bash ./$(version)/$(variant)/hooks/post_push
+
 BUILD_R_IMAGES += build-$(version)-$(variant)
 REBUILD_R_IMAGES += rebuild-$(version)-$(variant)
 TEST_R_IMAGES += test-$(version)-$(variant)
@@ -109,12 +114,16 @@ pull-$(version)-$(variant):
 push-$(version)-$(variant):
 	docker push $(BASE_IMAGE):$(version)-$(variant)
 
+push-rstudio-$(version)-$(variant):
+	docker push $(BASE_IMAGE_RSTUDIO):$(version)-$(variant)
+
 ifeq (yes,$(INCLUDE_PATCH_VERSIONS))
 BUILD_R_IMAGES += build-$(version)-$(variant)
 REBUILD_R_IMAGES += rebuild-$(version)-$(variant)
 TEST_R_IMAGES += test-$(version)-$(variant)
 PULL_R_IMAGES += pull-$(version)-$(variant)
 PUSH_R_IMAGES += push-$(version)-$(variant)
+PUSH_R_IMAGES_RSTUDIO += push-rstudio-$(version)-$(variant)
 endif
 endef
 
@@ -133,6 +142,8 @@ test-all: $(TEST_R_IMAGES)
 pull-all: $(PULL_R_IMAGES)
 
 push-all: $(PUSH_R_IMAGES)
+
+push-all-rstudio: $(PUSH_R_IMAGES_RSTUDIO)
 
 print-variants:
 	@echo $(VARIANTS)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Posit R Docker Images
 
+!!!warning These images have moved to `posit/r-base` on Docker Hub. The images at `rstudio/r-base` will continue to be updated for now, but will be deprecated in the future.
+
 [![R Docker](https://github.com/rstudio/r-docker/actions/workflows/build.yml/badge.svg)](https://github.com/rstudio/r-docker/actions/workflows/build.yml)
 
 Posit creates and [distributes an opinionated set of R
@@ -19,14 +21,14 @@ refer to the [Rocker project](https://www.rocker-project.org/).
 These images can be used to execute R:
 
 ```
-docker run --rm -it rstudio/r-base:4.3-jammy
+docker run --rm -it posit/r-base:4.3-jammy
 ```
 
 These images can also be used as the basis for other custom images. To get
 started, use an image as the base in a Dockerfile:
 
 ```dockerfile
-FROM rstudio/r-base:4.3-jammy
+FROM posit/r-base:4.3-jammy
 ```
 
 ### Releases and Tags
@@ -35,9 +37,9 @@ The images follow these tag patterns:
 
 | Pattern | Example | Description |
 | --- | --- | --- | 
-| `rstudio/r-base:distro` | `rstudio/r-base:focal` |  Base operating system + system libraries required by R. |
-| `rstudio/r-base:x.y.z-distro` | `rstudio/r-base:4.0.3-focal` | R version `x.y.z` on the specified OS |
-| `rstudio/r-base:x.y-distro` | `rstudio/r-base:4.0-focal` | Latest R version `x.y.z` on the specified OS, where the patch version `z` floats over time. For example, if R 4.0.4 is released, `rstudio/r-base:4.0-focal` would switch from R 4.0.3 to R 4.0.4.|
+| `posit/r-base:distro` | `posit/r-base:focal` |  Base operating system + system libraries required by R. |
+| `posit/r-base:x.y.z-distro` | `posit/r-base:4.0.3-focal` | R version `x.y.z` on the specified OS |
+| `posit/r-base:x.y-distro` | `posit/r-base:4.0-focal` | Latest R version `x.y.z` on the specified OS, where the patch version `z` floats over time. For example, if R 4.0.4 is released, `posit/r-base:4.0-focal` would switch from R 4.0.3 to R 4.0.4.|
 
 
 The following distributions are supported:  


### PR DESCRIPTION
## Description

This migrates the main DockerHub repo from `rstudio/r-base` to `posit/r-base`. It continues to push to `rstudio/r-base` and adds a note about future deprecation of that repo.