### PR TITLE
fix: add repos to build matrix to properly push to each orgs repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,10 @@ on:
         required: true
       DOCKERHUB_TOKEN:
         required: true
+      RSTUDIO_DOCKERHUB_USERNAME:
+        required: true
+      RSTUDIO_DOCKERHUB_TOKEN:
+        required: true
 
 permissions:
   contents: read
@@ -61,11 +65,11 @@ jobs:
   setup-matrix:
     runs-on: ubuntu-latest
     outputs:
-      variants: ${{ steps.setup-matrix.outputs.variants }}
+      matrix: ${{ steps.setup-matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up matrix of variants
+      - name: Set up matrix
         id: setup-matrix
         run: |
           if [[ "${{ inputs.variants }}" != "" ]]; then
@@ -73,19 +77,40 @@ jobs:
           else
             variants="$(make print-variants)"
           fi
-          variants=$(echo "$variants" | jq -R -c '[splits(" ")]')
-          echo "variants=$variants" >> $GITHUB_OUTPUT
+          
+          # Create matrix combining variants with organization repo
+          matrix=$(echo "$variants" | tr ' ' '\n' | jq -R -n '
+          {
+            "include": [
+              ( inputs | select(length>0) as $variant | [
+                {
+                  variant: $variant,
+                  username_secret: "DOCKERHUB_USERNAME",
+                  token_secret: "DOCKERHUB_TOKEN",
+                  repo: "posit/r-base"
+                },
+                {
+                  variant: $variant,
+                  username_secret: "RSTUDIO_DOCKERHUB_USERNAME",
+                  token_secret: "RSTUDIO_DOCKERHUB_TOKEN",
+                  repo: "rstudio/r-base"
+                }
+              ] )
+              | .[]
+            ]
+          }' | jq -c .)
+          echo "matrix=$matrix" >> $GITHUB_OUTPUT
 
   docker-images:
     needs: setup-matrix
     strategy:
       fail-fast: false
-      matrix:
-        variant: ${{ fromJson(needs.setup-matrix.outputs.variants) }}
+      matrix: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
     runs-on: ubuntu-latest
-    name: Docker images (${{ matrix.variant }})
+    name: Docker images (${{ matrix.repo }}:${{ matrix.variant }})
     env:
       VARIANTS: ${{ matrix.variant }}
+      BASE_IMAGE: ${{ matrix.repo }}
     steps:
       - uses: actions/checkout@v3
 
@@ -95,11 +120,11 @@ jobs:
           driver: docker
           install: true
 
-      - name: Login to Posit DockerHub
+      - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets[matrix.username_secret] }}
+          password: ${{ secrets[matrix.token_secret] }}
 
       - name: Setup environment
         run: |
@@ -119,18 +144,7 @@ jobs:
         run: |
           make test-all
 
-      - name: Push Posit images
+      - name: Push images
         if: ${{ github.ref == 'refs/heads/main' || inputs.publish_images }}
         run: |
           make push-all
-
-      - name: Login to RStudio DockerHub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.RSTUDIO_DOCKERHUB_USERNAME }}
-          password: ${{ secrets.RSTUDIO_DOCKERHUB_TOKEN }}
-
-      - name: Push RStudio images
-        if: ${{ github.ref == 'refs/heads/main' || inputs.publish_images }}
-        run: |
-          make push-all-rstudio

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
-BASE_IMAGE ?= posit/r-base
+BASE_IMAGE_POSIT ?= posit/r-base
 BASE_IMAGE_RSTUDIO ?= rstudio/r-base
+BASE_IMAGE ?= $(BASE_IMAGE_POSIT)
 VERSIONS ?= 3.1 3.2 3.3 3.4 3.5 3.6 4.0 4.1 4.2 4.3 4.4 devel next
 VARIANTS ?= focal jammy noble bullseye bookworm centos7 rockylinux8 rockylinux9 opensuse155 opensuse156
 
@@ -61,10 +62,6 @@ push-$(version)-$(variant):
 	docker push $(BASE_IMAGE):$(version)-$(variant)
 	IMAGE_NAME=$(BASE_IMAGE):$(version)-$(variant) DOCKER_REPO=$(BASE_IMAGE) bash ./$(version)/$(variant)/hooks/post_push
 
-push-rstudio-$(version)-$(variant):
-	docker push $(BASE_IMAGE_RSTUDIO):$(version)-$(variant)
-	IMAGE_NAME=$(BASE_IMAGE_RSTUDIO):$(version)-$(variant) DOCKER_REPO=$(BASE_IMAGE_RSTUDIO) bash ./$(version)/$(variant)/hooks/post_push
-
 BUILD_R_IMAGES += build-$(version)-$(variant)
 REBUILD_R_IMAGES += rebuild-$(version)-$(variant)
 TEST_R_IMAGES += test-$(version)-$(variant)
@@ -114,16 +111,12 @@ pull-$(version)-$(variant):
 push-$(version)-$(variant):
 	docker push $(BASE_IMAGE):$(version)-$(variant)
 
-push-rstudio-$(version)-$(variant):
-	docker push $(BASE_IMAGE_RSTUDIO):$(version)-$(variant)
-
 ifeq (yes,$(INCLUDE_PATCH_VERSIONS))
 BUILD_R_IMAGES += build-$(version)-$(variant)
 REBUILD_R_IMAGES += rebuild-$(version)-$(variant)
 TEST_R_IMAGES += test-$(version)-$(variant)
 PULL_R_IMAGES += pull-$(version)-$(variant)
 PUSH_R_IMAGES += push-$(version)-$(variant)
-PUSH_R_IMAGES_RSTUDIO += push-rstudio-$(version)-$(variant)
 endif
 endef
 
@@ -142,8 +135,6 @@ test-all: $(TEST_R_IMAGES)
 pull-all: $(PULL_R_IMAGES)
 
 push-all: $(PUSH_R_IMAGES)
-
-push-all-rstudio: $(PUSH_R_IMAGES_RSTUDIO)
 
 print-variants:
 	@echo $(VARIANTS)


### PR DESCRIPTION
## Description

I noticed that the images are not being properly pushed to the `rstudio/r-base` repo with the changes I made adding the `posit/r-base` as the `BASE_IMAGE`. I removed what I added before because it felt messy and instead added the repo/org secrets as part of the GHA build matrix. This should ensure each image is being built and tagged properly, and then authenticating and pushing to the correct repo.

The build matrix looks like this now:
```json
{
  "include": [
    {
      "variant": "focal",
      "username_secret": "DOCKERHUB_USERNAME",
      "token_secret": "DOCKERHUB_TOKEN",
      "repo": "posit/r-base"
    },
    {
      "variant": "focal",
      "username_secret": "RSTUDIO_DOCKERHUB_USERNAME",
      "token_secret": "RSTUDIO_DOCKERHUB_TOKEN",
      "repo": "rstudio/r-base"
    },
    {
      "variant": "jammy",
      "username_secret": "DOCKERHUB_USERNAME",
      "token_secret": "DOCKERHUB_TOKEN",
      "repo": "posit/r-base"
    },
    {
      "variant": "jammy",
      "username_secret": "RSTUDIO_DOCKERHUB_USERNAME",
      "token_secret": "RSTUDIO_DOCKERHUB_TOKEN",
      "repo": "rstudio/r-base"
    },
    {
      "variant": "noble",
      "username_secret": "DOCKERHUB_USERNAME",
      "token_secret": "DOCKERHUB_TOKEN",
      "repo": "posit/r-base"
    },
    {
      "variant": "noble",
      "username_secret": "RSTUDIO_DOCKERHUB_USERNAME",
      "token_secret": "RSTUDIO_DOCKERHUB_TOKEN",
      "repo": "rstudio/r-base"
    },
    {
      "variant": "bullseye",
      "username_secret": "DOCKERHUB_USERNAME",
      "token_secret": "DOCKERHUB_TOKEN",
      "repo": "posit/r-base"
    },
    {
      "variant": "bullseye",
      "username_secret": "RSTUDIO_DOCKERHUB_USERNAME",
      "token_secret": "RSTUDIO_DOCKERHUB_TOKEN",
      "repo": "rstudio/r-base"
    },
    {
      "variant": "bookworm",
      "username_secret": "DOCKERHUB_USERNAME",
      "token_secret": "DOCKERHUB_TOKEN",
      "repo": "posit/r-base"
    },
    {
      "variant": "bookworm",
      "username_secret": "RSTUDIO_DOCKERHUB_USERNAME",
      "token_secret": "RSTUDIO_DOCKERHUB_TOKEN",
      "repo": "rstudio/r-base"
    },
    {
      "variant": "centos7",
      "username_secret": "DOCKERHUB_USERNAME",
      "token_secret": "DOCKERHUB_TOKEN",
      "repo": "posit/r-base"
    },
    {
      "variant": "centos7",
      "username_secret": "RSTUDIO_DOCKERHUB_USERNAME",
      "token_secret": "RSTUDIO_DOCKERHUB_TOKEN",
      "repo": "rstudio/r-base"
    },
    {
      "variant": "rockylinux8",
      "username_secret": "DOCKERHUB_USERNAME",
      "token_secret": "DOCKERHUB_TOKEN",
      "repo": "posit/r-base"
    },
    {
      "variant": "rockylinux8",
      "username_secret": "RSTUDIO_DOCKERHUB_USERNAME",
      "token_secret": "RSTUDIO_DOCKERHUB_TOKEN",
      "repo": "rstudio/r-base"
    },
    {
      "variant": "rockylinux9",
      "username_secret": "DOCKERHUB_USERNAME",
      "token_secret": "DOCKERHUB_TOKEN",
      "repo": "posit/r-base"
    },
    {
      "variant": "rockylinux9",
      "username_secret": "RSTUDIO_DOCKERHUB_USERNAME",
      "token_secret": "RSTUDIO_DOCKERHUB_TOKEN",
      "repo": "rstudio/r-base"
    },
    {
      "variant": "opensuse155",
      "username_secret": "DOCKERHUB_USERNAME",
      "token_secret": "DOCKERHUB_TOKEN",
      "repo": "posit/r-base"
    },
    {
      "variant": "opensuse155",
      "username_secret": "RSTUDIO_DOCKERHUB_USERNAME",
      "token_secret": "RSTUDIO_DOCKERHUB_TOKEN",
      "repo": "rstudio/r-base"
    },
    {
      "variant": "opensuse156",
      "username_secret": "DOCKERHUB_USERNAME",
      "token_secret": "DOCKERHUB_TOKEN",
      "repo": "posit/r-base"
    },
    {
      "variant": "opensuse156",
      "username_secret": "RSTUDIO_DOCKERHUB_USERNAME",
      "token_secret": "RSTUDIO_DOCKERHUB_TOKEN",
      "repo": "rstudio/r-base"
    }
  ]
}
```