### PR TITLE
use larger gha runner for building images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,7 +106,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4x
     name: Docker images (${{ matrix.repo }}:${{ matrix.variant }})
     env:
       VARIANTS: ${{ matrix.variant }}


### PR DESCRIPTION
`opensuse155` fails to build and push tags, presumably because of how long it takes and running out of disk space: https://github.com/rstudio/r-docker/actions/runs/13295961698/job/37127876207#logs

This attempts to bump the runner size to mitigate those issues.