### PR TITLE
Reenable tests for R-devel fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,9 +142,7 @@ jobs:
 
       - name: Test images
         run: |
-          echo "skipping tests for now because they are broken"
-          # TODO fix tests and re-enable
-          # make test-all
+          make test-all
 
       - name: Push images
         if: ${{ github.ref == 'refs/heads/main' || inputs.publish_images }}

--- a/test/test.R
+++ b/test/test.R
@@ -2,8 +2,8 @@
 options(repos = c("https://cloud.r-project.org", "http://cloud.r-project.org"))
 
 # Check that packages can be installed
-install.packages("R6")
-library(R6)
+install.packages("testit")
+library(testit)
 
 # Check that the time zone database is present
 # https://stat.ethz.ch/R-manual/R-devel/library/base/html/timezones.html


### PR DESCRIPTION
This reverts commit 0872fd07fea93ab82288c66bdb6ff1eec80af547.

R-devel builds were fixed in https://github.com/rstudio/r-builds/pull/244 and rebuilt.

CI is probably going to fail for a few hours until the R-devel packages get invalidated in the CDN