### PR TITLE
Limit parallel builds to prevent running out of disk space

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,6 +106,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
+      # Reduce max-parallel in case of `out of space` errors, particularly on the full patch version builds
+      max-parallel: 10
     runs-on: ubuntu-latest-4x
     name: Docker images (${{ matrix.repo }}:${{ matrix.variant }})
     env:


### PR DESCRIPTION
Going to see if this works as a simple stopgap for the full patch version builds. Trying it out at https://github.com/rstudio/r-docker/actions/runs/13467039052/job/37634850116

This seems to work. The only error there was some transient error with pushing to Docker Hub rather than a disk space issue.