### PR TITLE
Add find command to rockylinux8 base image

### DIFF
--- a/base/rockylinux8/Dockerfile
+++ b/base/rockylinux8/Dockerfile
@@ -3,6 +3,8 @@ LABEL maintainer="Posit Docker <docker@posit.co>"
 
 RUN dnf -y update && \
     dnf -y install \
+    # Some R packages rely on the find command in their configuration scripts
+    findutils \
     fontconfig \
     glibc-langpack-en \
     perl-Digest-MD5 \

--- a/test/test.sh
+++ b/test/test.sh
@@ -32,5 +32,8 @@ pandoc --version
 echo -e '# Title\ncontent' | pandoc --output $DIR/test.pdf
 rm $DIR/test.pdf
 
+# find should be installed, as some R packages depend on it implicitly
+find --version
+
 # R tests
 Rscript $DIR/test.R


### PR DESCRIPTION
`find` is usually installed by default, but not on RHEL/Rocky 8's base image. In this specific case, the s2 package needs it for its config script: https://github.com/r-spatial/s2/blob/1764fe73e54556b98c721df6a8e83d93bf02d83b/configure#L98-L99

find is never specified as a system requirement either, so the best place is probably here in the base image.