### PR TITLE
Remove deprecated 'install' input from setup-buildx-action v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,7 +134,6 @@ jobs:
           # with building images that depend on another local image.
           # https://github.com/docker/buildx/issues/847
           driver: docker
-          install: true
 
       - name: Login to Docker Hub
         if: ${{ github.actor != 'dependabot[bot]' }}
@@ -211,7 +210,6 @@ jobs:
           # with building images that depend on another local image.
           # https://github.com/docker/buildx/issues/847
           driver: docker
-          install: true
 
       - name: Login to Docker Hub
         if: ${{ github.actor != 'dependabot[bot]' }}
@@ -265,7 +263,6 @@ jobs:
           # with building images that depend on another local image.
           # https://github.com/docker/buildx/issues/847
           driver: docker
-          install: true
 
       - name: Login to Docker Hub
         if: ${{ github.actor != 'dependabot[bot]' }}


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                              
  - Remove deprecated `install: true` input from `docker/setup-buildx-action@v4`                                                                                                                          
  - The `install` input was removed in v4 because buildx is now installed by default                                                                                                                      
  - Fixes CI failures introduced by #141                                                                                                                                                                  

<img width="1097" height="394" alt="image" src="https://github.com/user-attachments/assets/1a5d843b-05fe-46e5-a706-7ae723f6895b" />


                                                                                                                                                                                                          
  ## Test plan                                                                                                                                                                                            
  - [x] Verify CI workflow passes on both amd64 and arm64 jobs 